### PR TITLE
fix: Loosen Python version requirement in Pipfile

### DIFF
--- a/kost1ktrade/backend/Pipfile
+++ b/kost1ktrade/backend/Pipfile
@@ -17,4 +17,3 @@ pandas = "*"
 
 [requires]
 python_version = "3.12"
-python_full_version = "3.12.11"


### PR DESCRIPTION
Removes the `python_full_version` from the `[requires]` section of the Pipfile.

This makes the Python version requirement more flexible, allowing any patch version of Python 3.12 (e.g., 3.12.4) to be used without generating a warning from `pipenv`. This resolves an issue reported by the user when setting up the environment locally.