### PR TITLE
fix(config): Update Pydantic validator for SYMBOLS field

### DIFF
--- a/kost1ktrade/backend/src/core/config.py
+++ b/kost1ktrade/backend/src/core/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import List, Optional
 
@@ -83,7 +83,7 @@ class Settings(BaseSettings):
     OKX_WS_URL: str = "wss://ws.okx.com:8443/ws/v5/public"
     MAX_CANDLES: int = 5000
 
-    @validator('SYMBOLS', pre=True)
+    @field_validator('SYMBOLS', mode='before')
     def split_symbols(cls, v):
         if isinstance(v, str):
             return [item.strip() for item in v.split(',')]


### PR DESCRIPTION
Updates the validator syntax for the `SYMBOLS` field in `core/config.py` from the Pydantic V1 `@validator` to the V2 `@field_validator`.

This resolves a `JSONDecodeError` that occurred when parsing a comma-separated string for `SYMBOLS` from a .env file. The new Pydantic version expects lists to be in JSON format by default, and the updated validator with `mode='before'` correctly processes the raw string before parsing, restoring the intended behavior.