### PR TITLE
fix(config): Use computed_field for SYMBOLS parsing

### DIFF
--- a/kost1ktrade/backend/.env.example
+++ b/kost1ktrade/backend/.env.example
@@ -33,7 +33,7 @@ GEMINI_API_KEY=your_google_gemini_api_key
 
 # --- General Bot Settings ---
 # Comma-separated list of symbols to trade.
-SYMBOLS=BTC-USDT,ETH-USDT,SOL-USDT,LINK-USDT
+SYMBOLS_RAW=BTC-USDT,ETH-USDT,SOL-USDT,LINK-USDT
 # OKX WebSocket URL for public data streams.
 OKX_WS_URL=wss://ws.okx.com:8443/ws/v5/public
 # Maximum number of candles to fetch for analysis.

--- a/kost1ktrade/backend/src/core/config.py
+++ b/kost1ktrade/backend/src/core/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import List, Optional
 
@@ -79,15 +79,17 @@ class Settings(BaseSettings):
     GEMINI_API_KEY: Optional[str] = None
 
     # --- General Bot Settings ---
-    SYMBOLS: List[str] = ["BTC-USDT", "ETH-USDT", "SOL-USDT", "LINK-USDT"]
+    # Raw comma-separated string for symbols from .env
+    SYMBOLS_RAW: str = "BTC-USDT,ETH-USDT,SOL-USDT,LINK-USDT"
+
+    @computed_field
+    @property
+    def SYMBOLS(self) -> List[str]:
+        """Returns a list of symbols from the raw string."""
+        return [item.strip() for item in self.SYMBOLS_RAW.split(',')]
+
     OKX_WS_URL: str = "wss://ws.okx.com:8443/ws/v5/public"
     MAX_CANDLES: int = 5000
-
-    @field_validator('SYMBOLS', mode='before')
-    def split_symbols(cls, v):
-        if isinstance(v, str):
-            return [item.strip() for item in v.split(',')]
-        return v
 
     # --- Backtest Settings ---
     BACKTEST: RiskManagementSettings = Field(default_factory=RiskManagementSettings)


### PR DESCRIPTION
Refactors the `Settings` class in `core/config.py` to robustly handle comma-separated strings for the `SYMBOLS` list from a .env file.

The previous fix using `@field_validator` did not work as intended. This commit replaces that approach with a Pydantic V2 `computed_field`. The configuration now reads `SYMBOLS_RAW` as a simple string and provides a computed `SYMBOLS` property that returns the parsed list.

This completely avoids the JSON-parsing behavior for list types and definitively resolves the `JSONDecodeError`. The `.env.example` file has also been updated to reflect the change to `SYMBOLS_RAW`.