### PR TITLE
feat: Implement dynamic strategy framework and add MACD

### DIFF
--- a/jules-scratch/verification/verify_strategy_launch.py
+++ b/jules-scratch/verification/verify_strategy_launch.py
@@ -1,0 +1,44 @@
+import re
+from playwright.sync_api import sync_playwright, Page, expect
+
+def run_verification(page: Page):
+    """
+    This script verifies that a user can navigate to the Strategy Manager,
+    launch a bot with the MACD strategy, and see a success message.
+    """
+    # 1. Arrange: Go to the application's homepage.
+    # The frontend server runs on port 5173.
+    page.goto("http://localhost:5173")
+
+    # 2. Act: Navigate to the Strategy Manager page.
+    # We use get_by_role for robust selection.
+    strategy_link = page.get_by_role("link", name="Strategies")
+    strategy_link.click()
+
+    # 3. Assert: Check if we are on the correct page.
+    # The `expect` function will wait for the element to be visible.
+    expect(page.get_by_role("heading", name="Strategy Manager")).to_be_visible()
+
+    # 4. Act: Launch the bot using the default MACD parameters.
+    launch_button = page.get_by_role("button", name="Launch Bot")
+    launch_button.click()
+
+    # 5. Assert: Check for the success feedback message.
+    # The message might take a moment to appear after the API call.
+    success_message = page.locator(".feedback-message.success")
+    expect(success_message).to_be_visible()
+    expect(success_message).to_contain_text(re.compile("Bot .* started successfully!|Signal bot .* start process initiated.", re.IGNORECASE))
+
+    # 6. Screenshot: Capture the final state for visual verification.
+    page.screenshot(path="jules-scratch/verification/verification.png")
+
+# --- Playwright Boilerplate ---
+def main():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        run_verification(page)
+        browser.close()
+
+if __name__ == "__main__":
+    main()

--- a/kost1ktrade/backend/src/api/main.py
+++ b/kost1ktrade/backend/src/api/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, HTTPException, BackgroundTasks
 from pydantic import BaseModel
-from typing import Literal
+from typing import Literal, Dict, Any
 
 from src.core.bot_state import bot_state
 from src.core.bot_controller import start_bot_loop, stop_bot_loop, signal_trading_loop
@@ -25,22 +25,28 @@ async def get_balance():
 
 # --- Signal Bot Control ---
 
-class SignalBotControlRequest(BaseModel):
+class SignalBotStartRequest(BaseModel):
     mode: Literal['real', 'demo']
+    strategy_name: str
+    strategy_params: Dict[str, Any]
 
 @app.post("/signal-bot/start", tags=["Signal Bot Control"])
-async def start_signal_bot(request: SignalBotControlRequest, background_tasks: BackgroundTasks):
+async def start_signal_bot(request: SignalBotStartRequest, background_tasks: BackgroundTasks):
     """
-    Starts the signal-based trading bot in the specified mode.
+    Starts the signal-based trading bot with a specific strategy and parameters.
     The bot will run in a background task.
     """
     try:
-        print(f"Received request to start signal bot in '{request.mode}' mode.")
-        start_bot_loop(request.mode)
+        print(f"Received request to start signal bot in '{request.mode}' mode with strategy '{request.strategy_name}'.")
+        start_bot_loop(
+            mode=request.mode,
+            strategy_name=request.strategy_name,
+            strategy_params=request.strategy_params
+        )
         # Add the main loop to background tasks
         background_tasks.add_task(signal_trading_loop)
-        return {"message": f"Signal bot start process initiated in {request.mode} mode."}
-    except (ValueError, ConnectionError) as e:
+        return {"message": f"Signal bot '{request.strategy_name}' start process initiated in {request.mode} mode."}
+    except (ValueError, ConnectionError, TypeError) as e:
         raise HTTPException(status_code=400, detail=str(e))
 
 @app.post("/signal-bot/stop", tags=["Signal Bot Control"])

--- a/kost1ktrade/backend/src/core/bot_controller.py
+++ b/kost1ktrade/backend/src/core/bot_controller.py
@@ -1,24 +1,37 @@
 import time
 import pandas as pd
+import importlib
+from typing import Dict, Any
 from src.core.bot_state import bot_state
 from src.data_collector.collector import DataCollector
 from src.trading.engine import TradingEngine
-from src.strategies.sma_crossover import SmaCrossoverStrategy
 from src.core.config import settings
+
+def _get_strategy_class(strategy_name: str):
+    """Dynamically imports and returns a strategy class."""
+    try:
+        module_name = f"src.strategies.{strategy_name.lower()}"
+        # Convention: a file like 'macd.py' contains a class named 'MacdStrategy'
+        class_name = f"{strategy_name.replace('_', ' ').title().replace(' ', '')}Strategy"
+        strategy_module = importlib.import_module(module_name)
+        return getattr(strategy_module, class_name)
+    except (ImportError, AttributeError) as e:
+        raise ValueError(f"Could not find strategy '{strategy_name}'. "
+                         f"Ensure '{module_name}.py' and class '{class_name}' exist.") from e
 
 def signal_trading_loop():
     """
     The main loop for the signal-based trading bot.
     This function is intended to be run in a background task.
     """
-    # This check is important because the background task starts after the response is sent
     if bot_state.signal_bot_mode == "stopped":
         print("Bot was stopped before the trading loop could start.")
         return
 
     engine = bot_state.signal_bot_engine
-    if not engine:
-        print("FATAL in thread: Trading engine not available in bot_state.")
+    strategy = bot_state.signal_bot_strategy
+    if not engine or not strategy:
+        print("FATAL in thread: Trading engine or strategy not available in bot_state.")
         bot_state.signal_bot_mode = "stopped"
         return
 
@@ -29,26 +42,24 @@ def signal_trading_loop():
         bot_state.signal_bot_mode = "stopped"
         return
 
-    strategy = SmaCrossoverStrategy(
-        short_window=settings.INDICATORS.SMA_PERIOD,
-        long_window=settings.INDICATORS.SMA_LONG_PERIOD
-    )
+    # TODO: These should be parameterized and passed during bot startup
     symbol = settings.SYMBOLS[0]
     timeframe = '1h'
     sleep_duration_seconds = 3600
+    # Use a generic candle limit, as strategies have different requirements
+    candle_limit = 200
 
-    print(f"--- Background signal bot loop started in '{bot_state.signal_bot_mode}' mode for {symbol} ---")
+    print(f"--- Background signal bot loop started for {strategy.__class__.__name__} on {symbol} ---")
 
     try:
         while not bot_state.signal_bot_stop_event.is_set():
             try:
-                print(f"({time.ctime()}) --- Signal Bot Cycle ---")
+                print(f"({time.ctime()}) --- Signal Bot Cycle for {strategy.__class__.__name__} ---")
 
-                # Full fetch-analyze-execute logic
-                print(f"Fetching latest {strategy.long_window} candles for {symbol}...")
-                candles_list = collector.fetch_candles(symbol, timeframe, limit=strategy.long_window)
-                if not candles_list or len(candles_list) < strategy.long_window:
-                    raise ValueError(f"Could not fetch enough candle data")
+                print(f"Fetching latest {candle_limit} candles for {symbol}...")
+                candles_list = collector.fetch_candles(symbol, timeframe, limit=candle_limit)
+                if not candles_list or len(candles_list) < 50: # Basic check for some data
+                    raise ValueError(f"Could not fetch enough candle data (got {len(candles_list)})")
 
                 candles_df = pd.DataFrame(candles_list, columns=['open_time', 'open', 'high', 'low', 'close', 'volume'])
 
@@ -80,9 +91,10 @@ def signal_trading_loop():
         print(f"--- Background signal bot loop for '{bot_state.signal_bot_mode}' mode has gracefully stopped ---")
         bot_state.signal_bot_mode = "stopped"
         bot_state.signal_bot_engine = None
+        bot_state.signal_bot_strategy = None
 
 
-def start_bot_loop(mode: str):
+def start_bot_loop(mode: str, strategy_name: str, strategy_params: Dict[str, Any]):
     """
     Prepares the state for the signal-based bot to be started in a background task.
     """
@@ -92,13 +104,21 @@ def start_bot_loop(mode: str):
     bot_state.signal_bot_stop_event.clear()
 
     try:
-        # Initialize engine first. If this fails, state is not set to running.
+        # Initialize strategy first
+        StrategyClass = _get_strategy_class(strategy_name)
+        bot_state.signal_bot_strategy = StrategyClass(**strategy_params)
+
+        # Initialize engine
         bot_state.signal_bot_engine = TradingEngine(mode=mode)
-        # Only set mode to running after successful initialization
+
+        # Set mode to running only after successful initialization
         bot_state.signal_bot_mode = mode
-        print(f"Signal bot state prepared for '{mode}' mode.")
-    except Exception as e:
-        bot_state.signal_bot_mode = "stopped" # Reset on failure
+        print(f"Signal bot state prepared for '{mode}' mode with strategy '{strategy_name}'.")
+    except (ValueError, TypeError, ConnectionError) as e:
+        # Reset state on failure
+        bot_state.signal_bot_mode = "stopped"
+        bot_state.signal_bot_strategy = None
+        bot_state.signal_bot_engine = None
         raise e
 
 def stop_bot_loop():

--- a/kost1ktrade/backend/src/core/bot_state.py
+++ b/kost1ktrade/backend/src/core/bot_state.py
@@ -4,6 +4,7 @@ from typing import Optional, TYPE_CHECKING
 # Use TYPE_CHECKING to avoid circular imports at runtime
 if TYPE_CHECKING:
     from src.trading.engine import TradingEngine
+    from src.strategies.base import BaseStrategy
 
 class BotState:
     """
@@ -13,6 +14,7 @@ class BotState:
         # State for the signal-based bot
         self.signal_bot_mode: str = "stopped"  # 'stopped', 'real', 'demo'
         self.signal_bot_engine: Optional['TradingEngine'] = None
+        self.signal_bot_strategy: Optional['BaseStrategy'] = None
         self.signal_bot_thread: Optional[threading.Thread] = None
         self.signal_bot_stop_event: threading.Event = threading.Event()
 

--- a/kost1ktrade/backend/src/strategies/macd.py
+++ b/kost1ktrade/backend/src/strategies/macd.py
@@ -1,0 +1,57 @@
+import pandas as pd
+from .base import BaseStrategy
+
+class MacdStrategy(BaseStrategy):
+    """
+    A strategy based on the Moving Average Convergence Divergence (MACD).
+    """
+    def __init__(self,
+                 fast_period: int = 12,
+                 slow_period: int = 26,
+                 signal_period: int = 9):
+        self.fast_period = fast_period
+        self.slow_period = slow_period
+        self.signal_period = signal_period
+        print(f"MacdStrategy initialized with periods: fast={fast_period}, slow={slow_period}, signal={signal_period}")
+
+    def generate_signals(self, candles_df: pd.DataFrame) -> pd.DataFrame:
+        """
+        Calculates MACD and generates BUY/SELL signals on crossover.
+        - BUY signal when the MACD line crosses above the signal line.
+        - SELL signal when the MACD line crosses below the signal line.
+        """
+        if 'close' not in candles_df.columns:
+            raise ValueError("Candles DataFrame must contain a 'close' column.")
+
+        df = candles_df.copy()
+
+        # Calculate Fast and Slow EMAs
+        ema_fast = df['close'].ewm(span=self.fast_period, adjust=False).mean()
+        ema_slow = df['close'].ewm(span=self.slow_period, adjust=False).mean()
+
+        # Calculate MACD line
+        df['macd'] = ema_fast - ema_slow
+
+        # Calculate Signal line
+        df['signal_line'] = df['macd'].ewm(span=self.signal_period, adjust=False).mean()
+
+        # Calculate Histogram
+        df['histogram'] = df['macd'] - df['signal_line']
+
+        # Generate signals based on crossover
+        df['signal'] = 'HOLD'
+
+        # Find where the crossover happened in the previous step
+        previous_macd = df['macd'].shift(1)
+        previous_signal_line = df['signal_line'].shift(1)
+
+        # A BUY signal is generated when the MACD crosses ABOVE the signal line
+        buy_conditions = (df['macd'] > df['signal_line']) & (previous_macd <= previous_signal_line)
+
+        # A SELL signal is generated when the MACD crosses BELOW the signal line
+        sell_conditions = (df['macd'] < df['signal_line']) & (previous_macd >= previous_signal_line)
+
+        df.loc[buy_conditions, 'signal'] = 'BUY'
+        df.loc[sell_conditions, 'signal'] = 'SELL'
+
+        return df

--- a/kost1ktrade/frontend/package-lock.json
+++ b/kost1ktrade/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "axios": "^1.7.2",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^7.8.2"
       },
       "devDependencies": {
         "@types/react": "^18.2.66",
@@ -1816,6 +1817,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3223,6 +3233,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.2.tgz",
+      "integrity": "sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3346,6 +3394,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/kost1ktrade/frontend/package.json
+++ b/kost1ktrade/frontend/package.json
@@ -10,9 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "axios": "^1.7.2"
+    "react-router-dom": "^7.8.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/kost1ktrade/frontend/src/App.tsx
+++ b/kost1ktrade/frontend/src/App.tsx
@@ -1,15 +1,22 @@
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Sidebar from './components/Sidebar';
 import Dashboard from './pages/Dashboard';
+import StrategyManager from './pages/StrategyManager';
 import './App.css';
 
 function App() {
   return (
-    <div className="app-container">
-      <Sidebar />
-      <main className="main-content">
-        <Dashboard />
-      </main>
-    </div>
+    <Router>
+      <div className="app-container">
+        <Sidebar />
+        <main className="main-content">
+          <Routes>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/strategies" element={<StrategyManager />} />
+          </Routes>
+        </main>
+      </div>
+    </Router>
   )
 }
 

--- a/kost1ktrade/frontend/src/components/Sidebar.tsx
+++ b/kost1ktrade/frontend/src/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { NavLink } from 'react-router-dom';
 import './Sidebar.css';
 
 const Sidebar = () => {
@@ -9,10 +10,11 @@ const Sidebar = () => {
       </div>
       <nav>
         <ul>
-          <li className="active"><a href="#">Dashboard</a></li>
-          <li><a href="#">Strategies</a></li>
-          <li><a href="#">Backtesting</a></li>
-          <li><a href="#">Settings</a></li>
+          <li><NavLink to="/" end>Dashboard</NavLink></li>
+          <li><NavLink to="/strategies">Strategies</NavLink></li>
+          {/* These are placeholders for now */}
+          <li><a href="#" className="disabled-link">Backtesting</a></li>
+          <li><a href="#" className="disabled-link">Settings</a></li>
         </ul>
       </nav>
     </div>

--- a/kost1ktrade/frontend/src/pages/StrategyManager.css
+++ b/kost1ktrade/frontend/src/pages/StrategyManager.css
@@ -1,0 +1,107 @@
+.strategy-manager {
+    padding: 2rem;
+    background-color: #1f2229;
+    border-radius: 8px;
+    color: #e0e0e0;
+}
+
+.strategy-manager h2 {
+    color: #61dafb;
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+}
+
+.strategy-manager p {
+    margin-bottom: 2rem;
+    color: #a0a0a0;
+}
+
+.strategy-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.form-group label {
+    font-weight: bold;
+    font-size: 0.9rem;
+    color: #c0c0c0;
+}
+
+.form-group input,
+.form-group select {
+    padding: 0.75rem;
+    border-radius: 4px;
+    border: 1px solid #444;
+    background-color: #2c3038;
+    color: #e0e0e0;
+    font-size: 1rem;
+}
+
+.form-group input:focus,
+.form-group select:focus {
+    outline: none;
+    border-color: #61dafb;
+    box-shadow: 0 0 0 2px rgba(97, 218, 251, 0.3);
+}
+
+fieldset {
+    border: 1px solid #444;
+    border-radius: 4px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+legend {
+    padding: 0 0.5rem;
+    color: #61dafb;
+    font-weight: bold;
+}
+
+.strategy-form button {
+    padding: 0.8rem 1.5rem;
+    border: none;
+    border-radius: 4px;
+    background-color: #61dafb;
+    color: #1a1a1a;
+    font-weight: bold;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.strategy-form button:hover:not(:disabled) {
+    background-color: #88eaff;
+}
+
+.strategy-form button:disabled {
+    background-color: #555;
+    cursor: not-allowed;
+}
+
+.feedback-message {
+    margin-top: 1.5rem;
+    padding: 1rem;
+    border-radius: 4px;
+    text-align: center;
+}
+
+.feedback-message.success {
+    background-color: rgba(46, 184, 92, 0.2);
+    color: #2eb85c;
+    border: 1px solid #2eb85c;
+}
+
+.feedback-message.error {
+    background-color: rgba(231, 76, 60, 0.2);
+    color: #e74c3c;
+    border: 1px solid #e74c3c;
+}

--- a/kost1ktrade/frontend/src/pages/StrategyManager.tsx
+++ b/kost1ktrade/frontend/src/pages/StrategyManager.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import './StrategyManager.css';
+
+// A simple type for the form state
+type StrategyParams = {
+  [key: string]: number | string;
+};
+
+const StrategyManager = () => {
+  const [selectedStrategy, setSelectedStrategy] = useState('MACD');
+  const [params, setParams] = useState<StrategyParams>({
+    fast_period: 12,
+    slow_period: 26,
+    signal_period: 9,
+  });
+  const [mode, setMode] = useState('demo');
+  const [isLoading, setIsLoading] = useState(false);
+  const [feedback, setFeedback] = useState({ type: '', message: '' });
+
+  const handleParamChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setParams({
+      ...params,
+      [e.target.name]: parseInt(e.target.value, 10),
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setFeedback({ type: '', message: '' });
+
+    const requestBody = {
+      mode,
+      strategy_name: selectedStrategy,
+      strategy_params: params,
+    };
+
+    try {
+      const response = await axios.post('/api/signal-bot/start', requestBody);
+      setFeedback({ type: 'success', message: response.data.message || 'Bot started successfully!' });
+    } catch (err: any) {
+      setFeedback({ type: 'error', message: err.response?.data?.detail || 'Failed to start bot.' });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // For now, the form is hardcoded for MACD.
+  // In the future, this would be dynamically generated based on the selected strategy.
+  const renderStrategyParams = () => {
+    switch (selectedStrategy) {
+      case 'MACD':
+        return (
+          <>
+            <div className="form-group">
+              <label htmlFor="fast_period">Fast Period</label>
+              <input
+                type="number"
+                id="fast_period"
+                name="fast_period"
+                value={params.fast_period || ''}
+                onChange={handleParamChange}
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="slow_period">Slow Period</label>
+              <input
+                type="number"
+                id="slow_period"
+                name="slow_period"
+                value={params.slow_period || ''}
+                onChange={handleParamChange}
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="signal_period">Signal Period</label>
+              <input
+                type="number"
+                id="signal_period"
+                name="signal_period"
+                value={params.signal_period || ''}
+                onChange={handleParamChange}
+              />
+            </div>
+          </>
+        );
+      // Add cases for other strategies like 'RSI', 'SMA_Crossover' here
+      default:
+        return <p>Select a strategy to configure its parameters.</p>;
+    }
+  };
+
+  return (
+    <div className="strategy-manager">
+      <h2>Strategy Manager</h2>
+      <p>Configure and launch a new signal bot.</p>
+
+      <form onSubmit={handleSubmit} className="strategy-form">
+        <div className="form-group">
+          <label htmlFor="strategy-select">Strategy</label>
+          <select
+            id="strategy-select"
+            value={selectedStrategy}
+            onChange={e => setSelectedStrategy(e.target.value)}
+          >
+            <option value="MACD">MACD</option>
+            {/* Future options: <option value="RSI">RSI</option> */}
+          </select>
+        </div>
+
+        <div className="form-group">
+            <label htmlFor="mode-select">Mode</label>
+            <select id="mode-select" value={mode} onChange={e => setMode(e.target.value)}>
+                <option value="demo">Demo</option>
+                <option value="real">Real</option>
+            </select>
+        </div>
+
+        <fieldset>
+          <legend>Strategy Parameters</legend>
+          {renderStrategyParams()}
+        </fieldset>
+
+        <button type="submit" disabled={isLoading}>
+          {isLoading ? 'Launching...' : 'Launch Bot'}
+        </button>
+      </form>
+
+      {feedback.message && (
+        <div className={`feedback-message ${feedback.type}`}>
+          {feedback.message}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default StrategyManager;


### PR DESCRIPTION
This commit introduces a major architectural refactor to the trading bot, moving it from a hardcoded, single-strategy system to a dynamic framework capable of supporting multiple strategies. It also includes the implementation of the MACD strategy and the necessary frontend components to control it.

Key changes:

- **Backend Refactoring:**
  - `bot_controller.py` has been generalized to dynamically import and run any strategy class based on a name and parameters.
  - `bot_state.py` was updated to hold the currently active strategy instance.
  - The API in `api/main.py` was updated to accept a `strategy_name` and `strategy_params` in the request body for starting a signal bot.

- **New MACD Strategy:**
  - Added `strategies/macd.py`, which implements the MACD crossover strategy, conforming to the `BaseStrategy` interface.

- **Frontend Strategy Manager:**
  - Created a new page at `/strategies` for managing and launching bots.
  - The page includes a form to select and configure the MACD strategy.
  - The application routing (`App.tsx`) and navigation (`Sidebar.tsx`) were updated using `react-router-dom` to include this new page.