### PR TITLE
fix(frontend): Downgrade react-router-dom to fix rendering bug

### DIFF
--- a/kost1ktrade/frontend/package.json
+++ b/kost1ktrade/frontend/package.json
@@ -13,7 +13,7 @@
     "axios": "^1.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^7.8.2"
+    "react-router-dom": "^6.22.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",


### PR DESCRIPTION
The user reported that the frontend was not rendering any components, only a background animation. This was caused by an incompatibility between the routing code (written for `react-router-dom` v6) and the installed version of the library (`^7.8.2`).

This commit downgrades `react-router-dom` to a stable v6 release (`^6.22.0`) in `package.json`. This aligns the library version with the existing code, resolving the crash and allowing the UI to render correctly.