### PR TITLE
fix(frontend): Remove overflow:hidden to prevent UI from disappearing

### DIFF
--- a/kost1ktrade/frontend/src/index.css
+++ b/kost1ktrade/frontend/src/index.css
@@ -14,7 +14,6 @@ body {
   color: var(--primary-text);
   background: radial-gradient(ellipse at bottom, #1b2735 0%, #090a0f 100%);
   background-attachment: fixed;
-  overflow: hidden; /* Prevent body scroll */
 }
 
 h1, h2, h3 {


### PR DESCRIPTION
The user reported a bug where the UI was visible for a fraction of a second upon page load and would then disappear, leaving only the animated background.

This indicates that the initial render was successful, but a subsequent state update and re-render caused the main content container to be pushed out of the visible area. The `overflow: hidden` property on the `<body>` tag prevented scrollbars from appearing, making the content seem to have vanished entirely.

This commit removes the `overflow: hidden` style from `index.css`. This is a targeted fix that should resolve the rendering issue by allowing the content to be visible even if it overflows, without affecting the core application logic.