### PR TITLE
feat: Implement Simulation Deck for backtesting

### DIFF
--- a/kost1ktrade/frontend/src/App.tsx
+++ b/kost1ktrade/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Sidebar from './components/Sidebar';
 import Dashboard from './pages/Dashboard';
 import StrategyManager from './pages/StrategyManager';
+import SimulationDeck from './pages/SimulationDeck';
 import './App.css';
 
 function App() {
@@ -13,6 +14,7 @@ function App() {
           <Routes>
             <Route path="/" element={<Dashboard />} />
             <Route path="/strategies" element={<StrategyManager />} />
+            <Route path="/simulations" element={<SimulationDeck />} />
           </Routes>
         </main>
       </div>

--- a/kost1ktrade/frontend/src/components/Sidebar.tsx
+++ b/kost1ktrade/frontend/src/components/Sidebar.tsx
@@ -12,8 +12,8 @@ const Sidebar = () => {
         <ul>
           <li><NavLink to="/" end>Dashboard</NavLink></li>
           <li><NavLink to="/strategies">Strategies</NavLink></li>
-          {/* These are placeholders for now */}
-          <li><a href="#" className="disabled-link">Backtesting</a></li>
+          <li><NavLink to="/simulations">Simulation Deck</NavLink></li>
+          {/* This is a placeholder for now */}
           <li><a href="#" className="disabled-link">Settings</a></li>
         </ul>
       </nav>

--- a/kost1ktrade/frontend/src/pages/SimulationDeck.css
+++ b/kost1ktrade/frontend/src/pages/SimulationDeck.css
@@ -1,0 +1,143 @@
+/* Styles for the Simulation Deck page */
+.simulation-deck {
+  padding: 2rem;
+  color: #c0c0c0;
+}
+
+.simulation-deck h2 {
+  color: #00aeff;
+  border-bottom: 2px solid #00aeff;
+  padding-bottom: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.simulation-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  background-color: #1a202c;
+  padding: 2rem;
+  border-radius: 8px;
+  border: 1px solid #2d3748;
+}
+
+.form-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-group label {
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+  color: #a0aec0;
+}
+
+.form-group input,
+.form-group select {
+  padding: 0.75rem;
+  background-color: #2d3748;
+  border: 1px solid #4a5568;
+  border-radius: 4px;
+  color: #e2e8f0;
+  font-size: 1rem;
+}
+
+.form-group input:focus,
+.form-group select:focus {
+  outline: none;
+  border-color: #00aeff;
+  box-shadow: 0 0 0 2px rgba(0, 174, 255, 0.5);
+}
+
+.strategy-config {
+  background-color: #2d3748;
+  padding: 1.5rem;
+  border-radius: 6px;
+  margin-top: 1rem;
+  border: 1px solid #4a5568;
+}
+
+.strategy-config legend {
+  font-size: 1.1rem;
+  font-weight: bold;
+  color: #00aeff;
+  padding: 0 0.5rem;
+}
+
+.run-button {
+  grid-column: 1 / -1; /* Span all columns */
+  padding: 1rem;
+  background-color: #00aeff;
+  color: #ffffff;
+  border: none;
+  border-radius: 4px;
+  font-size: 1.2rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.run-button:disabled {
+  background-color: #4a5568;
+  cursor: not-allowed;
+}
+
+.run-button:not(:disabled):hover {
+  background-color: #007acc;
+}
+
+.results-container {
+  margin-top: 2rem;
+  background-color: #1a202c;
+  padding: 2rem;
+  border-radius: 8px;
+  border: 1px solid #2d3748;
+}
+
+.results-container h3 {
+  color: #00aeff;
+  margin-bottom: 1.5rem;
+}
+
+.results-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.results-table th,
+.results-table td {
+  padding: 1rem;
+  text-align: left;
+  border-bottom: 1px solid #2d3748;
+}
+
+.results-table th {
+  color: #a0aec0;
+}
+
+.results-table td {
+  color: #e2e8f0;
+}
+
+.feedback-message {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.feedback-message.error {
+  background-color: #e53e3e;
+  color: white;
+}
+
+.feedback-message.success {
+  background-color: #38a169;
+  color: white;
+}

--- a/kost1ktrade/frontend/src/pages/SimulationDeck.tsx
+++ b/kost1ktrade/frontend/src/pages/SimulationDeck.tsx
@@ -1,0 +1,220 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import './SimulationDeck.css';
+
+// Types to match the backend
+type StrategyParams = { [key: string]: number | string };
+type AvailableStrategies = { [key: string]: StrategyParams };
+type SimulationResult = {
+    strategy_name: string;
+    params: StrategyParams;
+    metrics: { [key: string]: number | string };
+    error?: string;
+};
+
+// Results Table Component
+const ResultsTable = ({ results }: { results: SimulationResult[] }) => {
+    if (!results || results.length === 0) {
+        return <p>No results to display.</p>;
+    }
+
+    // Assuming all results have the same metrics keys
+    const headers = Object.keys(results[0].metrics);
+
+    return (
+        <table className="results-table">
+            <thead>
+                <tr>
+                    <th>Strategy</th>
+                    {headers.map(header => <th key={header}>{header}</th>)}
+                </tr>
+            </thead>
+            <tbody>
+                {results.map((result, index) => (
+                    <tr key={index}>
+                        <td>{result.strategy_name}</td>
+                        {headers.map(header => (
+                            <td key={header}>
+                                {typeof result.metrics[header] === 'number'
+                                    ? (result.metrics[header] as number).toFixed(4)
+                                    : result.metrics[header]}
+                            </td>
+                        ))}
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    );
+};
+
+const SimulationDeck = () => {
+    // State for API data
+    const [availableStrategies, setAvailableStrategies] = useState<AvailableStrategies>({});
+
+    // State for form inputs
+    const [symbol, setSymbol] = useState('BTC/USDT');
+    const [timeframe, setTimeframe] = useState('1h');
+    const [startDate, setStartDate] = useState('2023-01-01');
+    const [endDate, setEndDate] = useState('2023-03-31');
+    const [selectedStrategy, setSelectedStrategy] = useState('');
+    const [strategyParams, setStrategyParams] = useState<StrategyParams>({});
+
+    // State for UI feedback
+    const [isLoading, setIsLoading] = useState(false);
+    const [feedback, setFeedback] = useState({ type: '', message: '' });
+    const [results, setResults] = useState<SimulationResult[] | null>(null);
+
+    // Fetch available strategies on component mount
+    useEffect(() => {
+        const fetchStrategies = async () => {
+            try {
+                const response = await axios.get('/api/strategies');
+                setAvailableStrategies(response.data);
+                const firstStrategyName = Object.keys(response.data)[0];
+                if (firstStrategyName) {
+                    setSelectedStrategy(firstStrategyName);
+                    setStrategyParams(response.data[firstStrategyName]);
+                }
+            } catch (error) {
+                console.error("Failed to fetch strategies", error);
+                setFeedback({ type: 'error', message: 'Could not load strategies from server.' });
+            }
+        };
+        fetchStrategies();
+    }, []);
+
+    // Handler for strategy selection change
+    const handleStrategyChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const newStrategyName = e.target.value;
+        setSelectedStrategy(newStrategyName);
+        setStrategyParams(availableStrategies[newStrategyName] || {});
+    };
+
+    // Handler for strategy parameter changes
+    const handleParamChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target;
+        const isNumeric = !isNaN(Number(value)) && value !== '';
+        setStrategyParams({
+            ...strategyParams,
+            [name]: isNumeric ? parseFloat(value) : value,
+        });
+    };
+
+    // Form submission handler
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setIsLoading(true);
+        setFeedback({ type: '', message: '' });
+        setResults(null);
+
+        const requestBody = {
+            symbol,
+            timeframe,
+            start_date: startDate,
+            end_date: endDate,
+            strategies: [
+                {
+                    name: selectedStrategy,
+                    params: strategyParams,
+                },
+            ],
+        };
+
+        try {
+            const response = await axios.post('/api/simulation/run', requestBody);
+            // Check for errors within the results
+            const hasError = response.data.some((res: SimulationResult) => res.error);
+            if (hasError) {
+                const errorMsg = response.data.find((res: SimulationResult) => res.error).error;
+                setFeedback({ type: 'error', message: `Simulation failed: ${errorMsg}` });
+            } else {
+                setResults(response.data);
+                setFeedback({ type: 'success', message: 'Simulation completed successfully!' });
+            }
+        } catch (err: any) {
+            setFeedback({ type: 'error', message: err.response?.data?.detail || 'Failed to run simulation.' });
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    // Render dynamic inputs for strategy parameters
+    const renderStrategyParams = () => {
+        if (!selectedStrategy) return null;
+        return Object.entries(strategyParams).map(([paramName, paramValue]) => (
+            <div className="form-group" key={paramName}>
+                <label htmlFor={paramName}>{paramName.replace(/_/g, ' ')}</label>
+                <input
+                    type="number"
+                    id={paramName}
+                    name={paramName}
+                    value={paramValue}
+                    onChange={handleParamChange}
+                    step="any"
+                />
+            </div>
+        ));
+    };
+
+    return (
+        <div className="simulation-deck">
+            <h2>Simulation Deck</h2>
+            <p>Configure and run a new backtest simulation.</p>
+
+            <form onSubmit={handleSubmit} className="simulation-form">
+                <div className="form-column">
+                    <div className="form-group">
+                        <label htmlFor="symbol">Symbol</label>
+                        <input type="text" id="symbol" value={symbol} onChange={e => setSymbol(e.target.value)} />
+                    </div>
+                    <div className="form-group">
+                        <label htmlFor="timeframe">Timeframe</label>
+                        <input type="text" id="timeframe" value={timeframe} onChange={e => setTimeframe(e.target.value)} />
+                    </div>
+                    <div className="form-group">
+                        <label htmlFor="start-date">Start Date</label>
+                        <input type="date" id="start-date" value={startDate} onChange={e => setStartDate(e.target.value)} />
+                    </div>
+                    <div className="form-group">
+                        <label htmlFor="end-date">End Date</label>
+                        <input type="date" id="end-date" value={endDate} onChange={e => setEndDate(e.target.value)} />
+                    </div>
+                </div>
+
+                <div className="form-column">
+                    <div className="form-group">
+                        <label htmlFor="strategy-select">Strategy</label>
+                        <select id="strategy-select" value={selectedStrategy} onChange={handleStrategyChange}>
+                            {Object.keys(availableStrategies).map(name => (
+                                <option key={name} value={name}>{name}</option>
+                            ))}
+                        </select>
+                    </div>
+                    <fieldset className="strategy-config">
+                        <legend>Strategy Parameters</legend>
+                        {renderStrategyParams()}
+                    </fieldset>
+                </div>
+
+                <button type="submit" className="run-button" disabled={isLoading}>
+                    {isLoading ? 'Running Simulation...' : 'Run Simulation'}
+                </button>
+            </form>
+
+            {feedback.message && (
+                <div className={`feedback-message ${feedback.type}`}>
+                    {feedback.message}
+                </div>
+            )}
+
+            {results && (
+                <div className="results-container">
+                    <h3>Simulation Results</h3>
+                    <ResultsTable results={results} />
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default SimulationDeck;


### PR DESCRIPTION
This commit introduces a new "Simulation Deck" feature to the frontend and standardizes the backend API routing.

Frontend:
- Creates a new page at `/simulations` for running backtest simulations.
- The UI allows users to configure the symbol, timeframe, date range, and strategy parameters.
- It calls the `/api/simulation/run` endpoint and displays the results in a table.
- Adds a link to the new page in the sidebar.

Backend:
- Refactors `src/api/main.py` to use an `APIRouter`.
- Prefixes all API endpoints with `/api` to align with the project's documentation and enable the frontend to connect correctly.