### PR TITLE
feat: Overhaul Strategy Manager with activation toggles

### DIFF
--- a/kost1ktrade/backend/src/api/main.py
+++ b/kost1ktrade/backend/src/api/main.py
@@ -176,16 +176,19 @@ def health_check():
     """Check if the API is running."""
     return {"status": "ok"}
 
-# --- Strategies ---
+# --- Strategy Management ---
 
-@router.get("/strategies", tags=["Strategies"])
-async def get_available_strategies():
+class StrategyStatusRequest(BaseModel):
+    statuses: Dict[str, bool]
+
+@router.get("/strategies/status", tags=["Strategies"])
+async def get_strategies_status():
     """
-    Returns a list of available signal-based strategies and their default parameters.
+    Returns a list of all available strategies, their default parameters,
+    and their current activation status.
     """
-    # This list is manually maintained for now.
-    # In a more advanced system, this could be discovered automatically.
-    strategies = {
+    # This list of params is manually maintained for now.
+    strategy_params = {
         "rsi": {"rsi_period": 14, "oversold_threshold": 30, "overbought_threshold": 70},
         "sma_crossover": {"short_window": 20, "long_window": 100},
         "macd": {"fast_period": 12, "slow_period": 26, "signal_period": 9},
@@ -196,7 +199,25 @@ async def get_available_strategies():
         "ichimoku": {"tenkan_period": 9, "kijun_period": 26, "senkou_b_period": 52},
         "bollinger_bands": {"bb_period": 20, "bb_std_dev": 2},
     }
-    return strategies
+
+    response = {}
+    for name, params in strategy_params.items():
+        response[name] = {
+            "params": params,
+            "active": bot_state.active_strategies.get(name, False)
+        }
+    return response
+
+@router.post("/strategies/status", tags=["Strategies"])
+async def set_strategies_status(request: StrategyStatusRequest):
+    """
+    Updates the activation status for multiple strategies.
+    """
+    print(f"Received request to update strategy statuses: {request.statuses}")
+    for name, status in request.statuses.items():
+        if name in bot_state.active_strategies:
+            bot_state.active_strategies[name] = status
+    return {"message": "Strategy statuses updated successfully.", "new_statuses": bot_state.active_strategies}
 
 # --- Simulation / Backtesting ---
 

--- a/kost1ktrade/backend/src/core/bot_state.py
+++ b/kost1ktrade/backend/src/core/bot_state.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING, Dict
 
 # Use TYPE_CHECKING to avoid circular imports at runtime
 if TYPE_CHECKING:
@@ -30,6 +30,20 @@ class BotState:
         self.master_bot_stop_event: threading.Event = threading.Event()
         self.market_state: Optional[str] = None
         self.adx_value: Optional[float] = None
+
+        # State for strategy activation
+        # Initialize all known strategies as active by default.
+        self.active_strategies: Dict[str, bool] = {
+            "rsi": True,
+            "sma_crossover": True,
+            "macd": True,
+            "stochastic": True,
+            "awesome_oscillator": True,
+            "parabolic_sar": True,
+            "keltner_channels": True,
+            "ichimoku": True,
+            "bollinger_bands": True,
+        }
 
 # Global instance of the bot state
 bot_state = BotState()

--- a/kost1ktrade/backend/src/core/master_controller.py
+++ b/kost1ktrade/backend/src/core/master_controller.py
@@ -144,12 +144,21 @@ def master_trading_loop():
                 if bot_state.signal_bot_mode != "stopped": stop_bot_loop()
                 continue
 
+            # Filter strategies based on their active status
+            runnable_strategies = [s for s in preferred_strategies if bot_state.active_strategies.get(s['name'], False)]
+            print(f"Found {len(preferred_strategies)} preferred strategies for {market_state}. After filtering, {len(runnable_strategies)} are active.")
+
+            if not runnable_strategies:
+                print("No active strategies available for the current market state. Stopping bot if running.")
+                if bot_state.signal_bot_mode != "stopped": stop_bot_loop()
+                continue
+
             # 4. Check Current Bot and Switch if Necessary
             current_strategy_name = getattr(bot_state, 'signal_bot_strategy_name', None)
-            is_current_strategy_suitable = any(s['name'] == current_strategy_name for s in preferred_strategies)
+            is_current_strategy_suitable = any(s['name'] == current_strategy_name for s in runnable_strategies)
 
             if not is_current_strategy_suitable:
-                new_strategy = random.choice(preferred_strategies)
+                new_strategy = random.choice(runnable_strategies)
                 print(f"Switching strategy! Current: '{current_strategy_name}', New Choice: '{new_strategy['name']}'")
 
                 if bot_state.signal_bot_mode != "stopped":

--- a/kost1ktrade/frontend/src/pages/SimulationDeck.css
+++ b/kost1ktrade/frontend/src/pages/SimulationDeck.css
@@ -2,6 +2,8 @@
 .simulation-deck {
   padding: 2rem;
   color: #c0c0c0;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .simulation-deck h2 {
@@ -13,7 +15,7 @@
 
 .simulation-form {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
   gap: 1.5rem;
   background-color: #1a202c;
   padding: 2rem;
@@ -24,18 +26,19 @@
 .form-column {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
 }
 
-.form-group {
+.form-group, .param-group {
   display: flex;
   flex-direction: column;
 }
 
-.form-group label {
+.form-group label, .param-group label {
   margin-bottom: 0.5rem;
   font-weight: bold;
   color: #a0aec0;
+  font-size: 0.9rem;
 }
 
 .form-group input,
@@ -56,18 +59,74 @@
 }
 
 .strategy-config {
-  background-color: #2d3748;
+  background-color: #161b25;
   padding: 1.5rem;
   border-radius: 6px;
-  margin-top: 1rem;
-  border: 1px solid #4a5568;
+  border: 1px solid #3a4458;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .strategy-config legend {
-  font-size: 1.1rem;
+  font-size: 1.2rem;
   font-weight: bold;
   color: #00aeff;
   padding: 0 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.strategy-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-height: 400px; /* Or adjust as needed */
+  overflow-y: auto;
+  padding-right: 1rem;
+}
+
+.strategy-item {
+  background-color: #2d3748;
+  padding: 1rem;
+  border-radius: 4px;
+  border-left: 3px solid #4a5568;
+}
+
+.strategy-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.strategy-toggle input[type="checkbox"] {
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+}
+
+.strategy-toggle label {
+  font-size: 1.1rem;
+  font-weight: bold;
+  color: #e2e8f0;
+  cursor: pointer;
+}
+
+.strategy-params {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #4a5568;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+}
+
+.param-group input {
+  padding: 0.5rem;
+  background-color: #1a202c;
+  border: 1px solid #4a5568;
+  border-radius: 4px;
+  color: #e2e8f0;
+  font-size: 0.9rem;
 }
 
 .run-button {

--- a/kost1ktrade/frontend/src/pages/SimulationDeck.tsx
+++ b/kost1ktrade/frontend/src/pages/SimulationDeck.tsx
@@ -2,9 +2,18 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import './SimulationDeck.css';
 
-// Types to match the backend
+// --- TYPE DEFINITIONS ---
 type StrategyParams = { [key: string]: number | string };
-type AvailableStrategies = { [key: string]: StrategyParams };
+
+type StrategyConfig = {
+  selected: boolean;
+  params: StrategyParams;
+};
+
+type StrategiesState = {
+  [strategyName: string]: StrategyConfig;
+};
+
 type SimulationResult = {
     strategy_name: string;
     params: StrategyParams;
@@ -12,18 +21,18 @@ type SimulationResult = {
     error?: string;
 };
 
-// Helper function to format snake_case to Title Case
+// --- HELPER FUNCTIONS ---
 const toTitleCase = (str: string) => {
     return str.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
 };
 
-// Results Table Component
+
+// --- SUB-COMPONENTS ---
 const ResultsTable = ({ results }: { results: SimulationResult[] }) => {
     if (!results || results.length === 0) {
         return <p>No results to display.</p>;
     }
 
-    // Assuming all results have the same metrics keys
     const headers = Object.keys(results[0].metrics);
 
     return (
@@ -36,15 +45,19 @@ const ResultsTable = ({ results }: { results: SimulationResult[] }) => {
             </thead>
             <tbody>
                 {results.map((result, index) => (
-                    <tr key={index}>
+                    <tr key={index} className={result.error ? 'error-row' : ''}>
                         <td>{toTitleCase(result.strategy_name)}</td>
-                        {headers.map(header => (
-                            <td key={header}>
-                                {typeof result.metrics[header] === 'number'
-                                    ? (result.metrics[header] as number).toFixed(4)
-                                    : result.metrics[header]}
-                            </td>
-                        ))}
+                        {result.error ? (
+                            <td colSpan={headers.length} className="error-message">{result.error}</td>
+                        ) : (
+                            headers.map(header => (
+                                <td key={header}>
+                                    {typeof result.metrics[header] === 'number'
+                                        ? (result.metrics[header] as number).toFixed(4)
+                                        : result.metrics[header]}
+                                </td>
+                            ))
+                        )}
                     </tr>
                 ))}
             </tbody>
@@ -52,17 +65,17 @@ const ResultsTable = ({ results }: { results: SimulationResult[] }) => {
     );
 };
 
-const SimulationDeck = () => {
-    // State for API data
-    const [availableStrategies, setAvailableStrategies] = useState<AvailableStrategies>({});
 
+// --- MAIN COMPONENT ---
+const SimulationDeck = () => {
     // State for form inputs
     const [symbol, setSymbol] = useState('BTC/USDT');
     const [timeframe, setTimeframe] = useState('1h');
     const [startDate, setStartDate] = useState('2023-01-01');
     const [endDate, setEndDate] = useState('2023-03-31');
-    const [selectedStrategy, setSelectedStrategy] = useState('');
-    const [strategyParams, setStrategyParams] = useState<StrategyParams>({});
+
+    // State for strategies
+    const [strategies, setStrategies] = useState<StrategiesState>({});
 
     // State for UI feedback
     const [isLoading, setIsLoading] = useState(false);
@@ -74,12 +87,15 @@ const SimulationDeck = () => {
         const fetchStrategies = async () => {
             try {
                 const response = await axios.get('/api/strategies');
-                setAvailableStrategies(response.data);
-                const firstStrategyName = Object.keys(response.data)[0];
-                if (firstStrategyName) {
-                    setSelectedStrategy(firstStrategyName);
-                    setStrategyParams(response.data[firstStrategyName]);
+                const availableStrategies: { [key: string]: StrategyParams } = response.data;
+                const initialStrategiesState: StrategiesState = {};
+                for (const name in availableStrategies) {
+                    initialStrategiesState[name] = {
+                        selected: false, // Start with all strategies deselected
+                        params: availableStrategies[name],
+                    };
                 }
+                setStrategies(initialStrategiesState);
             } catch (error) {
                 console.error("Failed to fetch strategies", error);
                 setFeedback({ type: 'error', message: 'Could not load strategies from server.' });
@@ -88,54 +104,60 @@ const SimulationDeck = () => {
         fetchStrategies();
     }, []);
 
-    // Handler for strategy selection change
-    const handleStrategyChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-        const newStrategyName = e.target.value;
-        setSelectedStrategy(newStrategyName);
-        setStrategyParams(availableStrategies[newStrategyName] || {});
+    // --- EVENT HANDLERS ---
+
+    const handleStrategyToggle = (strategyName: string) => {
+        setStrategies(prev => ({
+            ...prev,
+            [strategyName]: {
+                ...prev[strategyName],
+                selected: !prev[strategyName].selected,
+            },
+        }));
     };
 
-    // Handler for strategy parameter changes
-    const handleParamChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const { name, value } = e.target;
+    const handleParamChange = (strategyName: string, paramName: string, value: string) => {
         const isNumeric = !isNaN(Number(value)) && value !== '';
-        setStrategyParams({
-            ...strategyParams,
-            [name]: isNumeric ? parseFloat(value) : value,
-        });
+        setStrategies(prev => ({
+            ...prev,
+            [strategyName]: {
+                ...prev[strategyName],
+                params: {
+                    ...prev[strategyName].params,
+                    [paramName]: isNumeric ? parseFloat(value) : value,
+                },
+            },
+        }));
     };
 
-    // Form submission handler
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         setIsLoading(true);
         setFeedback({ type: '', message: '' });
         setResults(null);
 
+        const selectedStrategies = Object.entries(strategies)
+            .filter(([, config]) => config.selected)
+            .map(([name, config]) => ({ name, params: config.params }));
+
+        if (selectedStrategies.length === 0) {
+            setFeedback({ type: 'error', message: 'Please select at least one strategy to run.' });
+            setIsLoading(false);
+            return;
+        }
+
         const requestBody = {
             symbol,
             timeframe,
             start_date: startDate,
             end_date: endDate,
-            strategies: [
-                {
-                    name: selectedStrategy,
-                    params: strategyParams,
-                },
-            ],
+            strategies: selectedStrategies,
         };
 
         try {
             const response = await axios.post('/api/simulation/run', requestBody);
-            // Check for errors within the results
-            const hasError = response.data.some((res: SimulationResult) => res.error);
-            if (hasError) {
-                const errorMsg = response.data.find((res: SimulationResult) => res.error).error;
-                setFeedback({ type: 'error', message: `Simulation failed: ${errorMsg}` });
-            } else {
-                setResults(response.data);
-                setFeedback({ type: 'success', message: 'Simulation completed successfully!' });
-            }
+            setResults(response.data);
+            setFeedback({ type: 'success', message: 'Simulation completed!' });
         } catch (err: any) {
             setFeedback({ type: 'error', message: err.response?.data?.detail || 'Failed to run simulation.' });
         } finally {
@@ -143,61 +165,70 @@ const SimulationDeck = () => {
         }
     };
 
-    // Render dynamic inputs for strategy parameters
-    const renderStrategyParams = () => {
-        if (!selectedStrategy) return null;
-        return Object.entries(strategyParams).map(([paramName, paramValue]) => (
-            <div className="form-group" key={paramName}>
-                <label htmlFor={paramName}>{toTitleCase(paramName)}</label>
-                <input
-                    type="number"
-                    id={paramName}
-                    name={paramName}
-                    value={paramValue}
-                    onChange={handleParamChange}
-                    step="any"
-                />
-            </div>
-        ));
-    };
-
     return (
         <div className="simulation-deck">
             <h2>Simulation Deck</h2>
-            <p>Configure and run a new backtest simulation.</p>
+            <p>Select and configure strategies to run a comparative backtest.</p>
 
             <form onSubmit={handleSubmit} className="simulation-form">
+                {/* --- Column 1: General Settings --- */}
                 <div className="form-column">
-                    <div className="form-group">
-                        <label htmlFor="symbol">Symbol</label>
-                        <input type="text" id="symbol" value={symbol} onChange={e => setSymbol(e.target.value)} />
-                    </div>
-                    <div className="form-group">
-                        <label htmlFor="timeframe">Timeframe</label>
-                        <input type="text" id="timeframe" value={timeframe} onChange={e => setTimeframe(e.target.value)} />
-                    </div>
-                    <div className="form-group">
-                        <label htmlFor="start-date">Start Date</label>
-                        <input type="date" id="start-date" value={startDate} onChange={e => setStartDate(e.target.value)} />
-                    </div>
-                    <div className="form-group">
-                        <label htmlFor="end-date">End Date</label>
-                        <input type="date" id="end-date" value={endDate} onChange={e => setEndDate(e.target.value)} />
-                    </div>
+                    <fieldset className="strategy-config">
+                        <legend>General Settings</legend>
+                        <div className="form-group">
+                            <label htmlFor="symbol">Symbol</label>
+                            <input type="text" id="symbol" value={symbol} onChange={e => setSymbol(e.target.value)} />
+                        </div>
+                        <div className="form-group">
+                            <label htmlFor="timeframe">Timeframe</label>
+                            <input type="text" id="timeframe" value={timeframe} onChange={e => setTimeframe(e.target.value)} />
+                        </div>
+                        <div className="form-group">
+                            <label htmlFor="start-date">Start Date</label>
+                            <input type="date" id="start-date" value={startDate} onChange={e => setStartDate(e.target.value)} />
+                        </div>
+                        <div className="form-group">
+                            <label htmlFor="end-date">End Date</label>
+                            <input type="date" id="end-date" value={endDate} onChange={e => setEndDate(e.target.value)} />
+                        </div>
+                    </fieldset>
                 </div>
 
+                {/* --- Column 2: Strategy Selection & Configuration --- */}
                 <div className="form-column">
-                    <div className="form-group">
-                        <label htmlFor="strategy-select">Strategy</label>
-                        <select id="strategy-select" value={selectedStrategy} onChange={handleStrategyChange}>
-                            {Object.keys(availableStrategies).map(name => (
-                                <option key={name} value={name}>{toTitleCase(name)}</option>
+                     <fieldset className="strategy-config">
+                        <legend>Select Strategies</legend>
+                        <div className="strategy-list">
+                            {Object.entries(strategies).map(([name, config]) => (
+                                <div key={name} className="strategy-item">
+                                    <div className="strategy-toggle">
+                                        <input
+                                            type="checkbox"
+                                            id={`strategy-${name}`}
+                                            checked={config.selected}
+                                            onChange={() => handleStrategyToggle(name)}
+                                        />
+                                        <label htmlFor={`strategy-${name}`}>{toTitleCase(name)}</label>
+                                    </div>
+                                    {config.selected && (
+                                        <div className="strategy-params">
+                                            {Object.entries(config.params).map(([paramName, paramValue]) => (
+                                                <div className="param-group" key={paramName}>
+                                                    <label htmlFor={`${name}-${paramName}`}>{toTitleCase(paramName)}</label>
+                                                    <input
+                                                        type="number"
+                                                        id={`${name}-${paramName}`}
+                                                        value={paramValue}
+                                                        onChange={(e) => handleParamChange(name, paramName, e.target.value)}
+                                                        step="any"
+                                                    />
+                                                </div>
+                                            ))}
+                                        </div>
+                                    )}
+                                </div>
                             ))}
-                        </select>
-                    </div>
-                    <fieldset className="strategy-config">
-                        <legend>Strategy Parameters</legend>
-                        {renderStrategyParams()}
+                        </div>
                     </fieldset>
                 </div>
 

--- a/kost1ktrade/frontend/src/pages/StrategyManager.css
+++ b/kost1ktrade/frontend/src/pages/StrategyManager.css
@@ -1,107 +1,159 @@
-.strategy-manager {
-    padding: 2rem;
-    background-color: #1f2229;
-    border-radius: 8px;
-    color: #e0e0e0;
+.strategy-manager-page {
+  padding: 2rem;
+  color: #c0c0c0;
 }
 
-.strategy-manager h2 {
-    color: #61dafb;
-    margin-top: 0;
-    margin-bottom: 0.5rem;
+.strategy-manager-page h2 {
+  color: #00aeff;
+  border-bottom: 2px solid #00aeff;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
-.strategy-manager p {
+.strategy-manager-page p {
     margin-bottom: 2rem;
-    color: #a0a0a0;
+    color: #a0aec0;
 }
 
-.strategy-form {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
+.strategy-list-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
 }
 
-.form-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+.strategy-card {
+  background-color: #1a202c;
+  border: 1px solid #2d3748;
+  border-radius: 8px;
+  transition: all 0.3s ease;
+  overflow: hidden;
 }
 
-.form-group label {
+.strategy-card.active {
+    border-left: 5px solid #38a169;
+}
+
+.strategy-card:not(.active) {
+    border-left: 5px solid #4a5568;
+}
+
+.strategy-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background-color: #2d3748;
+}
+
+.strategy-card-header h3 {
+  margin: 0;
+  color: #e2e8f0;
+  font-size: 1.2rem;
+}
+
+.strategy-card-body {
+  padding: 1.5rem;
+}
+
+.strategy-card-body p {
+    margin-top: 0;
+    margin-bottom: 1rem;
     font-weight: bold;
+    color: #a0aec0;
+}
+
+.strategy-card-body ul {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
     font-size: 0.9rem;
-    color: #c0c0c0;
 }
 
-.form-group input,
-.form-group select {
-    padding: 0.75rem;
-    border-radius: 4px;
-    border: 1px solid #444;
-    background-color: #2c3038;
-    color: #e0e0e0;
-    font-size: 1rem;
-}
-
-.form-group input:focus,
-.form-group select:focus {
-    outline: none;
-    border-color: #61dafb;
-    box-shadow: 0 0 0 2px rgba(97, 218, 251, 0.3);
-}
-
-fieldset {
-    border: 1px solid #444;
-    border-radius: 4px;
-    padding: 1.5rem;
+.strategy-card-body li {
     display: flex;
-    flex-direction: column;
-    gap: 1rem;
+    justify-content: space-between;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #2d3748;
+}
+.strategy-card-body li:last-child {
+    border-bottom: none;
 }
 
-legend {
-    padding: 0 0.5rem;
-    color: #61dafb;
-    font-weight: bold;
+.strategy-card-body strong {
+    color: #a0aec0;
 }
 
-.strategy-form button {
-    padding: 0.8rem 1.5rem;
-    border: none;
-    border-radius: 4px;
-    background-color: #61dafb;
-    color: #1a1a1a;
-    font-weight: bold;
-    font-size: 1rem;
-    cursor: pointer;
-    transition: background-color 0.2s ease;
+/* The switch - the box around the slider */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 34px;
 }
 
-.strategy-form button:hover:not(:disabled) {
-    background-color: #88eaff;
+/* Hide default HTML checkbox */
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
 }
 
-.strategy-form button:disabled {
-    background-color: #555;
-    cursor: not-allowed;
+/* The slider */
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #4a5568;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 26px;
+  width: 26px;
+  left: 4px;
+  bottom: 4px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+input:checked + .slider {
+  background-color: #38a169;
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #38a169;
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
+}
+
+/* Rounded sliders */
+.slider.round {
+  border-radius: 34px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
 }
 
 .feedback-message {
-    margin-top: 1.5rem;
-    padding: 1rem;
-    border-radius: 4px;
-    text-align: center;
-}
-
-.feedback-message.success {
-    background-color: rgba(46, 184, 92, 0.2);
-    color: #2eb85c;
-    border: 1px solid #2eb85c;
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border-radius: 4px;
+  text-align: center;
 }
 
 .feedback-message.error {
-    background-color: rgba(231, 76, 60, 0.2);
-    color: #e74c3c;
-    border: 1px solid #e74c3c;
+  background-color: #e53e3e;
+  color: white;
 }

--- a/kost1ktrade/frontend/src/pages/StrategyManager.tsx
+++ b/kost1ktrade/frontend/src/pages/StrategyManager.tsx
@@ -1,131 +1,117 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import './StrategyManager.css';
 
+// --- TYPE DEFINITIONS ---
 type StrategyParams = { [key: string]: number | string };
-type AvailableStrategies = { [key: string]: StrategyParams };
 
+type StrategyInfo = {
+  active: boolean;
+  params: StrategyParams;
+};
+
+type StrategiesStatus = {
+  [strategyName: string]: StrategyInfo;
+};
+
+// --- HELPER FUNCTIONS ---
+const toTitleCase = (str: string) => {
+    return str.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+};
+
+
+// --- MAIN COMPONENT ---
 const StrategyManager = () => {
-  const [availableStrategies, setAvailableStrategies] = useState<AvailableStrategies>({});
-  const [selectedStrategy, setSelectedStrategy] = useState('');
-  const [params, setParams] = useState<StrategyParams>({});
-  const [mode, setMode] = useState('demo');
-  const [isLoading, setIsLoading] = useState(false);
+  const [strategies, setStrategies] = useState<StrategiesStatus>({});
+  const [isLoading, setIsLoading] = useState(true);
   const [feedback, setFeedback] = useState({ type: '', message: '' });
 
-  useEffect(() => {
-    const fetchStrategies = async () => {
-      try {
-        const response = await axios.get('/api/strategies');
-        setAvailableStrategies(response.data);
-        // Set the first strategy as the default selection
-        const firstStrategyName = Object.keys(response.data)[0];
-        if (firstStrategyName) {
-          setSelectedStrategy(firstStrategyName);
-          setParams(response.data[firstStrategyName]);
-        }
-      } catch (error) {
-        console.error("Failed to fetch strategies", error);
-        setFeedback({ type: 'error', message: 'Could not load strategies from server.' });
-      }
-    };
-    fetchStrategies();
-  }, []);
-
-  const handleStrategyChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newStrategyName = e.target.value;
-    setSelectedStrategy(newStrategyName);
-    setParams(availableStrategies[newStrategyName] || {});
-  };
-
-  const handleParamChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    // Handle both number and potential string inputs gracefully
-    const isNumeric = /^\d*\.?\d*$/.test(value) && value !== '';
-    setParams({
-      ...params,
-      [name]: isNumeric ? parseFloat(value) : value,
-    });
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsLoading(true);
-    setFeedback({ type: '', message: '' });
-
-    const requestBody = {
-      mode,
-      strategy_name: selectedStrategy,
-      strategy_params: params,
-    };
-
+  // Fetch strategies and their statuses on component mount
+  const fetchStrategyStatus = useCallback(async () => {
     try {
-      const response = await axios.post('/api/signal-bot/start', requestBody);
-      setFeedback({ type: 'success', message: response.data.message || 'Bot started successfully!' });
-    } catch (err: any) {
-      setFeedback({ type: 'error', message: err.response?.data?.detail || 'Failed to start bot.' });
+      const response = await axios.get('/api/strategies/status');
+      setStrategies(response.data);
+    } catch (error) {
+      console.error("Failed to fetch strategies status", error);
+      setFeedback({ type: 'error', message: 'Could not load strategies from server.' });
     } finally {
       setIsLoading(false);
     }
-  };
+  }, []);
 
-  const renderStrategyParams = () => {
-    if (!selectedStrategy) {
-      return <p>Select a strategy to configure its parameters.</p>;
+  useEffect(() => {
+    fetchStrategyStatus();
+  }, [fetchStrategyStatus]);
+
+  // Handler for toggling a strategy's active status
+  const handleToggle = async (strategyName: string) => {
+    const originalStrategies = { ...strategies };
+    const updatedStrategy = {
+      ...strategies[strategyName],
+      active: !strategies[strategyName].active,
+    };
+    const updatedStrategies = {
+      ...strategies,
+      [strategyName]: updatedStrategy,
+    };
+
+    // Optimistically update the UI
+    setStrategies(updatedStrategies);
+
+    // Create the request body for the single strategy update
+    const requestBody = {
+        statuses: {
+            [strategyName]: updatedStrategy.active
+        }
+    };
+
+    try {
+      await axios.post('/api/strategies/status', requestBody);
+      // Success, the optimistic update was correct.
+    } catch (error) {
+      console.error("Failed to update strategy status", error);
+      setFeedback({ type: 'error', message: `Failed to update ${toTitleCase(strategyName)}.` });
+      // Revert the UI on failure
+      setStrategies(originalStrategies);
     }
-    return Object.entries(params).map(([paramName, paramValue]) => (
-      <div className="form-group" key={paramName}>
-        <label htmlFor={paramName}>{paramName.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}</label>
-        <input
-          type="number"
-          id={paramName}
-          name={paramName}
-          value={paramValue}
-          onChange={handleParamChange}
-          step="any"
-        />
-      </div>
-    ));
   };
 
   return (
-    <div className="strategy-manager">
+    <div className="strategy-manager-page">
       <h2>Strategy Manager</h2>
-      <p>Configure and launch a new signal bot.</p>
+      <p>Activate or deactivate strategies for the Master Bot to use.</p>
 
-      <form onSubmit={handleSubmit} className="strategy-form">
-        <div className="form-group">
-          <label htmlFor="strategy-select">Strategy</label>
-          <select
-            id="strategy-select"
-            value={selectedStrategy}
-            onChange={handleStrategyChange}
-            disabled={!Object.keys(availableStrategies).length}
-          >
-            <option value="" disabled>-- Select a Strategy --</option>
-            {Object.keys(availableStrategies).map(name => (
-              <option key={name} value={name}>{name.replace(/_/g, ' ').toUpperCase()}</option>
-            ))}
-          </select>
+      {isLoading ? (
+        <p>Loading strategies...</p>
+      ) : (
+        <div className="strategy-list-container">
+          {Object.entries(strategies).map(([name, info]) => (
+            <div key={name} className={`strategy-card ${info.active ? 'active' : ''}`}>
+              <div className="strategy-card-header">
+                <h3>{toTitleCase(name)}</h3>
+                <label className="switch">
+                  <input
+                    type="checkbox"
+                    checked={info.active}
+                    onChange={() => handleToggle(name)}
+                  />
+                  <span className="slider round"></span>
+                </label>
+              </div>
+              <div className="strategy-card-body">
+                <p>Default Parameters:</p>
+                <ul>
+                  {Object.entries(info.params).map(([param, value]) => (
+                    <li key={param}>
+                      <strong>{toTitleCase(param)}:</strong> {value}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ))}
         </div>
-
-        <div className="form-group">
-            <label htmlFor="mode-select">Mode</label>
-            <select id="mode-select" value={mode} onChange={e => setMode(e.target.value)}>
-                <option value="demo">Demo</option>
-                <option value="real">Real</option>
-            </select>
-        </div>
-
-        <fieldset>
-          <legend>Strategy Parameters</legend>
-          {renderStrategyParams()}
-        </fieldset>
-
-        <button type="submit" disabled={isLoading}>
-          {isLoading ? 'Launching...' : 'Launch Bot'}
-        </button>
-      </form>
+      )}
 
       {feedback.message && (
         <div className={`feedback-message ${feedback.type}`}>

--- a/kost1ktrade/frontend/vite.config.ts
+++ b/kost1ktrade/frontend/vite.config.ts
@@ -6,19 +6,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/signal-bot': {
-        target: 'http://127.0.0.1:8000',
-        changeOrigin: true,
-      },
-      '/grid-bot': {
-        target: 'http://127.0.0.1:8000',
-        changeOrigin: true,
-      },
-      '/balance': {
-        target: 'http://127.0.0.1:8000',
-        changeOrigin: true,
-      },
-      '/health': {
+      '/api': {
         target: 'http://127.0.0.1:8000',
         changeOrigin: true,
       },


### PR DESCRIPTION
This commit redesigns the Strategy Manager feature to allow users to control which strategies are active for the Master Bot.

Backend:
- Adds `active_strategies` dictionary to `bot_state` to track the on/off status of each strategy.
- Modifies the API at `/api/strategies/status` to get and set these statuses.
- Updates the `master_controller` to filter for and use only the active strategies suitable for the current market state.

Frontend:
- Redesigns the `StrategyManager` page to display all strategies in a card layout.
- Each card has an on/off toggle switch to control its active status.
- The UI now communicates with the new API endpoints to manage strategy states.