### PR TITLE
Fix backend crash and improve symbol handling resilience

### DIFF
--- a/kost1ktrade/backend/Pipfile
+++ b/kost1ktrade/backend/Pipfile
@@ -18,6 +18,7 @@ scikit-learn = "*"
 textblob = "*"
 numpy = "*"
 pandas-ta = "*"
+requests = "*"
 
 [dev-packages]
 

--- a/kost1ktrade/backend/Pipfile.lock
+++ b/kost1ktrade/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a75d5748d820ad638f59fca1e1dbd626e3ebd3984ca0d94a8d5888b7c704b86b"
+            "sha256": "ce61160b2eab2c7b42720c24ece6dea97aeccc8fc5913a0ee7aef262e5bfd303"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1389,6 +1389,7 @@
                 "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6",
                 "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==2.32.5"
         },

--- a/kost1ktrade/backend/src/core/master_controller.py
+++ b/kost1ktrade/backend/src/core/master_controller.py
@@ -68,11 +68,17 @@ def master_trading_loop():
             symbol = random.choice(settings.SYMBOLS)
             print(f"--- Analyzing selected symbol: {symbol} ---")
 
-            # 1. Fetch Data
-            timeframe = '1h'
-            candles_list = collector.fetch_candles(symbol, timeframe, limit=500) # Fetch more data for feature generation
-            if not candles_list or len(candles_list) < 50:
-                raise ValueError("Not enough data fetched for analysis.")
+            try:
+                # 1. Fetch Data
+                timeframe = '1h'
+                candles_list = collector.fetch_candles(symbol, timeframe, limit=500) # Fetch more data for feature generation
+                if not candles_list or len(candles_list) < 50:
+                    raise ValueError("Not enough data fetched for analysis.")
+            except Exception as e:
+                print(f"ERROR: Could not fetch or process data for symbol '{symbol}'. Reason: {e}")
+                print("Skipping to the next cycle.")
+                bot_state.master_bot_stop_event.wait(timeout=10) # Short wait before next cycle
+                continue
 
             candles_df = pd.DataFrame(candles_list, columns=['open_time', 'open', 'high', 'low', 'close', 'volume'])
             candles_df['open_time'] = pd.to_datetime(candles_df['open_time'], unit='ms')

--- a/kost1ktrade/backend/src/data_collector/collector.py
+++ b/kost1ktrade/backend/src/data_collector/collector.py
@@ -16,7 +16,11 @@ class DataCollector:
         """
         try:
             exchange_class = getattr(ccxt, exchange_id)
-            self.exchange = exchange_class()
+            self.exchange = exchange_class({
+                'options': {
+                    'defaultType': 'spot',
+                },
+            })
         except AttributeError:
             raise ValueError(f"Exchange '{exchange_id}' is not supported by ccxt.")
 

--- a/scripts/temp_list_markets.py
+++ b/scripts/temp_list_markets.py
@@ -1,44 +1,53 @@
 import ccxt
-import sys
-import os
 
-# Add the project root to the python path to allow imports from src
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-def get_okx_symbols():
+def get_ccxt_okx_spot_symbols():
     """
-    Connects to OKX via ccxt and prints symbols related to BTC and USDT
-    to help find the correct format.
+    Fetches the list of all available SPOT instruments from OKX using the ccxt library.
     """
     try:
-        # We need to add the parent directory to the path to find the `src` module
-        # This is a common pattern for scripts inside a package
-
         exchange = ccxt.okx()
         markets = exchange.load_markets()
 
-        print("--- Finding OKX Symbol Formats ---")
-
-        # OKX uses perpetual swaps like BTC-USDT-SWAP or spot markets like BTC/USDT
-        # Let's find the spot market symbol
-        spot_symbols = [s for s in markets if s.endswith('/USDT') and 'BTC' in s]
-
-        if spot_symbols:
-            print("\nFound potential SPOT matches for BTC/USDT:")
-            for symbol in spot_symbols:
-                print(symbol)
-        else:
-            print("\nNo SPOT matches found for BTC/USDT.")
-
-        swap_symbols = [s for s in markets if 'BTC' in s and 'USDT-SWAP' in s]
-
-        if swap_symbols:
-            print("\nFound potential SWAP matches for BTC-USDT-SWAP:")
-            for symbol in swap_symbols:
-                print(symbol)
+        # We are interested in spot markets that are active
+        spot_symbols = [
+            symbol for symbol, market in markets.items()
+            if market.get('spot') and market.get('active')
+        ]
+        return spot_symbols
 
     except Exception as e:
-        print(f"An error occurred: {e}")
+        print(f"An error occurred while fetching data from ccxt: {e}")
+        return []
 
 if __name__ == "__main__":
-    get_okx_symbols()
+    print("Fetching available SPOT symbols from OKX using ccxt...")
+    live_symbols = get_ccxt_okx_spot_symbols()
+
+    if live_symbols:
+        print(f"Found {len(live_symbols)} live SPOT symbols.")
+
+        # Check for the specific symbols from the config
+        config_symbols = ["BTC/USDT", "ETH/USDT", "SOL/USDT", "LINK/USDT", "DOGE/USDT"]
+        print("\nChecking for symbols from config (using '/' separator as ccxt does):")
+
+        found_symbols = []
+        for symbol in config_symbols:
+            if symbol in live_symbols:
+                print(f" - Found '{symbol}'")
+                found_symbols.append(symbol)
+            else:
+                print(f" - Did NOT find '{symbol}'")
+
+        if found_symbols:
+            print("\nTo fix the config, use one of the found symbols.")
+            # CCXT uses '/', but the app was changed to use '-'. Let's provide both.
+            hyphenated_symbols = [s.replace('/', '-') for s in found_symbols]
+            print(f"Suggestion for 'SYMBOLS_RAW' in config.py (using hyphens):")
+            print(f'SYMBOLS_RAW: str = "{",".join(hyphenated_symbols)}"')
+        else:
+            print("\nCould not find any of the desired symbols. Here are some examples of what was found:")
+            for symbol in live_symbols[:15]:
+                print(symbol)
+
+    else:
+        print("Could not retrieve a list of symbols using ccxt.")


### PR DESCRIPTION
The backend application was crashing in a loop when the master controller encountered a trading symbol that was not available on the OKX exchange. This was caused by an unhandled exception in the data collector.

This commit introduces two main fixes:

1.  **Add robust error handling to the master controller:** The data fetching logic within the master controller's main loop is now wrapped in a try...except block. This prevents the entire application from crashing if an invalid symbol is encountered. It now logs the error and continues to the next cycle.

2.  **Explicitly set the default market type to 'spot':** The `DataCollector` now initializes the `ccxt` exchange object with the `defaultType` option set to `'spot'`. This ensures that symbols are correctly resolved to the spot market, preventing ambiguity between spot, futures, or swap markets, which was a likely contributor to the original error.