### PR TITLE
Fix KeyError in get_balance by adding a check for the 'free' key.

### DIFF
--- a/kost1ktrade/backend/src/trading/engine.py
+++ b/kost1ktrade/backend/src/trading/engine.py
@@ -48,7 +48,7 @@ class TradingEngine:
             return {
                 currency: data['free']
                 for currency, data in balance.items()
-                if data['free'] > 0
+                if isinstance(data, dict) and 'free' in data and data['free'] > 0
             }
         except ccxt.errors.BaseError as e:
             print(f"An error occurred while fetching balance: {e}")


### PR DESCRIPTION
The get_balance function in the trading engine was throwing a KeyError because it was not correctly handling the data structure returned by the ccxt library's fetch_balance() method. The returned dictionary contains not only currency balances but also other metadata.

This commit adds a check to ensure that the 'free' key exists and the value is a dictionary before accessing it, which makes the function more robust and prevents the error.