### PR TITLE
feat: Implement Grid Bot UI and fix trading logic

### DIFF
--- a/kost1ktrade/backend/src/api/main.py
+++ b/kost1ktrade/backend/src/api/main.py
@@ -81,34 +81,45 @@ async def get_signal_bot_status():
 
 # --- Grid Bot Control ---
 
-class GridBotStartRequest(BaseModel):
-    mode: Literal['real', 'demo']
+class GridBotSettings(BaseModel):
     symbol: str
-    amount_per_grid: float
     grid_range_low: float
     grid_range_high: float
     num_grids: int
+    amount_per_grid: float
+
+class GridBotModeRequest(BaseModel):
+    mode: Literal['real', 'demo']
+
+@router.get("/grid-bot/settings", tags=["Grid Bot Control"])
+async def get_grid_bot_settings():
+    """
+    Returns the current settings for the Grid Bot.
+    """
+    return bot_state.grid_bot_config
+
+@router.post("/grid-bot/settings", tags=["Grid Bot Control"])
+async def set_grid_bot_settings(settings: GridBotSettings):
+    """
+    Updates the settings for the Grid Bot.
+    """
+    if bot_state.grid_bot_mode != 'stopped':
+        raise HTTPException(status_code=400, detail="Cannot change settings while the Grid Bot is running.")
+    bot_state.grid_bot_config = settings.dict()
+    return {"message": "Grid Bot settings updated successfully."}
+
 
 @router.post("/grid-bot/start", tags=["Grid Bot Control"])
-async def start_grid_bot_endpoint(request: GridBotStartRequest, background_tasks: BackgroundTasks):
+async def start_grid_bot_endpoint(request: GridBotModeRequest, background_tasks: BackgroundTasks):
     """
-    Starts the grid trading bot with the specified configuration.
+    Starts the grid trading bot with the currently saved configuration.
     The bot will run in a background task.
     """
     try:
-        grid_config = {
-            "grid_range_low": request.grid_range_low,
-            "grid_range_high": request.grid_range_high,
-            "num_grids": request.num_grids,
-        }
-        start_grid_bot(request.mode, request.symbol, grid_config, request.amount_per_grid)
-        # Add the main loop to background tasks with its arguments
-        background_tasks.add_task(
-            grid_trading_loop,
-            request.symbol,
-            grid_config,
-            request.amount_per_grid
-        )
+        config = bot_state.grid_bot_config
+        start_grid_bot(mode=request.mode)
+        # Add the main loop to background tasks
+        background_tasks.add_task(grid_trading_loop)
         return {"message": "Grid bot start process initiated."}
     except (ValueError, ConnectionError) as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -227,15 +238,23 @@ def save_strategy_params(params: dict):
 async def get_strategies_status():
     """
     Returns a list of all available strategies, their current parameters from file,
-    and their current activation status.
+    and their current activation status. This now includes the Grid Bot.
     """
     strategy_params = load_strategy_params()
     response = {}
     for name, params in strategy_params.items():
         response[name] = {
             "params": params,
-            "active": bot_state.active_strategies.get(name, False)
+            "active": bot_state.active_strategies.get(name, False),
+            "type": "signal"
         }
+
+    # Add the Grid Bot as a special strategy type
+    response['grid'] = {
+        "params": bot_state.grid_bot_config,
+        "active": bot_state.grid_bot_mode != 'stopped',
+        "type": "grid"
+    }
     return response
 
 @router.post("/strategies/status", tags=["Strategies"])
@@ -327,8 +346,10 @@ async def run_simulation(request: SimulationRunRequest):
                     "metrics": result
                 })
             except Exception as e:
+                import traceback
                 # Log error for a specific strategy but continue with others
-                print(f"Error backtesting strategy {strategy_config.name}: {e}")
+                print(f"Error backtesting strategy {strategy_config.name}:")
+                traceback.print_exc() # Print the full traceback
                 all_results.append({
                     "strategy_name": strategy_config.name,
                     "params": strategy_config.params,

--- a/kost1ktrade/backend/src/core/backtester.py
+++ b/kost1ktrade/backend/src/core/backtester.py
@@ -15,6 +15,11 @@ class Backtester:
         """
         df = self.strategy.generate_signals(self.candles_df)
 
+        # Ensure signal column exists and fill NaNs
+        if 'signal' not in df.columns:
+            raise ValueError("The 'signal' column is missing from the strategy output.")
+        df['signal'].fillna('HOLD', inplace=True)
+
         balance = self.initial_balance
         position = 0.0  # Represents the amount of the base asset held
         equity_curve = [self.initial_balance]

--- a/kost1ktrade/backend/src/core/bot_controller.py
+++ b/kost1ktrade/backend/src/core/bot_controller.py
@@ -18,8 +18,9 @@ def signal_trading_loop():
 
     engine = bot_state.signal_bot_engine
     strategy = bot_state.signal_bot_strategy
-    if not engine or not strategy:
-        print("FATAL in thread: Trading engine or strategy not available in bot_state.")
+    symbol = bot_state.signal_bot_symbol
+    if not engine or not strategy or not symbol:
+        print("FATAL in thread: Trading engine, strategy, or symbol not available in bot_state.")
         bot_state.signal_bot_mode = "stopped"
         return
 
@@ -30,9 +31,7 @@ def signal_trading_loop():
         bot_state.signal_bot_mode = "stopped"
         return
 
-    # TODO: These should be parameterized and passed during bot startup
-    symbol = settings.SYMBOLS[0]
-    timeframe = '1h'
+    timeframe = '1h' # This could also be part of the state if needed
     sleep_duration_seconds = 3600
     # Use a generic candle limit, as strategies have different requirements
     candle_limit = 200
@@ -56,7 +55,7 @@ def signal_trading_loop():
                 latest_signal = result_df.iloc[-1]['signal']
                 print(f"Strategy: {strategy.__class__.__name__} | Signal: {latest_signal}")
 
-                base_currency, quote_currency = symbol.split('-')
+                base_currency, quote_currency = symbol.split('/')
                 if latest_signal == 'BUY':
                     balance = engine.get_balance()
                     quote_balance = balance.get(quote_currency, 0)
@@ -83,7 +82,7 @@ def signal_trading_loop():
         bot_state.signal_bot_strategy_name = None
 
 
-def start_bot_loop(mode: str, strategy_name: str, strategy_params: Dict[str, Any]):
+def start_bot_loop(mode: str, symbol: str, strategy_name: str, strategy_params: Dict[str, Any]):
     """
     Prepares the state for the signal-based bot to be started in a background task.
     """
@@ -103,13 +102,15 @@ def start_bot_loop(mode: str, strategy_name: str, strategy_params: Dict[str, Any
         # Set mode to running only after successful initialization
         bot_state.signal_bot_mode = mode
         bot_state.signal_bot_strategy_name = strategy_name
-        print(f"Signal bot state prepared for '{mode}' mode with strategy '{strategy_name}'.")
+        bot_state.signal_bot_symbol = symbol
+        print(f"Signal bot state prepared for '{mode}' mode with strategy '{strategy_name}' on symbol '{symbol}'.")
     except (ValueError, TypeError, ConnectionError) as e:
         # Reset state on failure
         bot_state.signal_bot_mode = "stopped"
         bot_state.signal_bot_strategy = None
         bot_state.signal_bot_strategy_name = None
         bot_state.signal_bot_engine = None
+        bot_state.signal_bot_symbol = None
         raise e
 
 def stop_bot_loop():

--- a/kost1ktrade/backend/src/core/bot_state.py
+++ b/kost1ktrade/backend/src/core/bot_state.py
@@ -16,6 +16,7 @@ class BotState:
         self.signal_bot_engine: Optional['TradingEngine'] = None
         self.signal_bot_strategy: Optional['BaseStrategy'] = None
         self.signal_bot_strategy_name: Optional[str] = None
+        self.signal_bot_symbol: Optional[str] = None
         self.signal_bot_thread: Optional[threading.Thread] = None
         self.signal_bot_stop_event: threading.Event = threading.Event()
 
@@ -24,6 +25,13 @@ class BotState:
         self.grid_bot_engine: Optional['TradingEngine'] = None
         self.grid_bot_thread: Optional[threading.Thread] = None
         self.grid_bot_stop_event: threading.Event = threading.Event()
+        self.grid_bot_config: Dict[str, Any] = {
+            "symbol": "ETH/USDT",
+            "grid_range_low": 1800,
+            "grid_range_high": 2200,
+            "num_grids": 10,
+            "amount_per_grid": 50, # This is in quote currency (e.g., USDT)
+        }
 
         # State for the master controller
         self.master_bot_mode: str = "stopped"

--- a/kost1ktrade/backend/src/core/config.py
+++ b/kost1ktrade/backend/src/core/config.py
@@ -92,7 +92,7 @@ class Settings(BaseSettings):
 
     # --- General Bot Settings ---
     # Raw comma-separated string for symbols from .env
-    SYMBOLS_RAW: str = "BTC-USDT,ETH-USDT,SOL-USDT,LINK-USDT"
+    SYMBOLS_RAW: str = "BTC/USDT,ETH/USDT,SOL/USDT,LINK/USDT"
 
     @computed_field
     @property

--- a/kost1ktrade/backend/src/core/grid_bot_controller.py
+++ b/kost1ktrade/backend/src/core/grid_bot_controller.py
@@ -4,7 +4,7 @@ from src.core.bot_state import bot_state
 from src.trading.engine import TradingEngine
 from src.strategies.grid import GridStrategy
 
-def grid_trading_loop(symbol: str, grid_config: dict, amount_per_grid: float):
+def grid_trading_loop():
     """
     The main loop for the grid trading bot.
     This function is intended to be run in a background task.
@@ -13,6 +13,15 @@ def grid_trading_loop(symbol: str, grid_config: dict, amount_per_grid: float):
         return
 
     engine = bot_state.grid_bot_engine
+    config = bot_state.grid_bot_config
+
+    symbol = config['symbol']
+    amount_per_grid = config['amount_per_grid']
+    grid_config = {
+        "grid_range_low": config['grid_range_low'],
+        "grid_range_high": config['grid_range_high'],
+        "num_grids": config['num_grids'],
+    }
     strategy = GridStrategy(**grid_config)
 
     print(f"--- Background grid bot loop started for {symbol} ---")
@@ -71,7 +80,7 @@ def grid_trading_loop(symbol: str, grid_config: dict, amount_per_grid: float):
         bot_state.grid_bot_engine = None
 
 
-def start_grid_bot(mode: str, symbol: str, grid_config: dict, amount_per_grid: float):
+def start_grid_bot(mode: str):
     """Prepares the state for the grid bot to be started in a background task."""
     if bot_state.grid_bot_mode != "stopped":
         raise ValueError("Grid bot is already running.")

--- a/kost1ktrade/backend/src/core/master_controller.py
+++ b/kost1ktrade/backend/src/core/master_controller.py
@@ -139,6 +139,7 @@ def master_trading_loop():
                 print(f"Starting new signal bot with strategy: {new_strategy_name}...")
                 start_bot_loop(
                     mode=bot_state.master_bot_target_mode,
+                    symbol=symbol,
                     strategy_name=new_strategy_name,
                     strategy_params=new_strategy_params
                 )

--- a/kost1ktrade/backend/src/strategies/ichimoku.py
+++ b/kost1ktrade/backend/src/strategies/ichimoku.py
@@ -28,29 +28,38 @@ class IchimokuStrategy(BaseStrategy):
         df = candles_df.copy()
 
         # Calculate Ichimoku Cloud using pandas-ta
-        ichimoku_df = df.ta.ichimoku(tenkan=self.tenkan_period, kijun=self.kijun_period, senkou=self.senkou_b_period)
+        # It returns a tuple of DataFrames, so we handle them accordingly
+        ichimoku_data, _ = df.ta.ichimoku(tenkan=self.tenkan_period, kijun=self.kijun_period, senkou=self.senkou_b_period)
 
-        # Extract the relevant columns
-        df['tenkan'] = ichimoku_df[f'ITS_{self.tenkan_period}']
-        df['kijun'] = ichimoku_df[f'IKS_{self.kijun_period}']
-        df['senkou_a'] = ichimoku_df[f'ISA_{self.tenkan_period}']
-        df['senkou_b'] = ichimoku_df[f'ISB_{self.kijun_period}']
+        # Concatenate the results back to the main DataFrame
+        df = pd.concat([df, ichimoku_data], axis=1)
+
+        # Define column names based on pandas-ta output
+        tenkan_col = f'ITS_{self.tenkan_period}'
+        kijun_col = f'IKS_{self.kijun_period}'
+        senkou_a_col = f'ISA_{self.tenkan_period}'
+        senkou_b_col = f'ISB_{self.kijun_period}'
+
+        # Ensure all required columns exist before proceeding
+        required_cols = [tenkan_col, kijun_col, senkou_a_col, senkou_b_col]
+        if not all(col in df.columns for col in required_cols):
+            raise ValueError(f"Ichimoku calculation failed. Missing columns: {[c for c in required_cols if c not in df.columns]}")
 
         df['signal'] = 'HOLD'
 
         # Previous state for crossover detection
-        previous_tenkan = df['tenkan'].shift(1)
-        previous_kijun = df['kijun'].shift(1)
+        previous_tenkan = df[tenkan_col].shift(1)
+        previous_kijun = df[kijun_col].shift(1)
 
         # Conditions for bullish crossover (TK Cross)
-        tk_cross_up = (df['tenkan'] > df['kijun']) & (previous_tenkan <= previous_kijun)
+        tk_cross_up = (df[tenkan_col] > df[kijun_col]) & (previous_tenkan <= previous_kijun)
 
         # Conditions for bearish crossover
-        tk_cross_down = (df['tenkan'] < df['kijun']) & (previous_tenkan >= previous_kijun)
+        tk_cross_down = (df[tenkan_col] < df[kijun_col]) & (previous_tenkan >= previous_kijun)
 
         # Cloud conditions
-        price_above_cloud = (df['close'] > df['senkou_a']) & (df['close'] > df['senkou_b'])
-        price_below_cloud = (df['close'] < df['senkou_a']) & (df['close'] < df['senkou_b'])
+        price_above_cloud = (df['close'] > df[senkou_a_col]) & (df['close'] > df[senkou_b_col])
+        price_below_cloud = (df['close'] < df[senkou_a_col]) & (df['close'] < df[senkou_b_col])
 
         # Final signal logic
         buy_conditions = tk_cross_up & price_above_cloud

--- a/kost1ktrade/backend/src/strategies/keltner_channels.py
+++ b/kost1ktrade/backend/src/strategies/keltner_channels.py
@@ -27,27 +27,28 @@ class KeltnerChannelsStrategy(BaseStrategy):
         df = candles_df.copy()
 
         # Calculate Keltner Channels using pandas-ta
-        kc = df.ta.kc(length=self.length, scalar=self.multiplier, atr_length=self.atr_length)
+        kc_df = df.ta.kc(length=self.length, scalar=self.multiplier, atr_length=self.atr_length)
+        df = pd.concat([df, kc_df], axis=1)
 
-        # Column names are like 'KCUe_20_2.0', 'KCL_20_2.0'
-        upper_band_col = f'KCUe_{self.length}_{self.multiplier}'
-        lower_band_col = f'KCL_{self.length}_{self.multiplier}'
-
-        df['kc_upper'] = kc[upper_band_col]
-        df['kc_lower'] = kc[lower_band_col]
+        # Find the column names dynamically
+        try:
+            upper_band_col = next(col for col in df.columns if col.startswith('KCUe'))
+            lower_band_col = next(col for col in df.columns if col.startswith('KCL'))
+        except StopIteration:
+            raise ValueError("Could not find Keltner Channel columns in the DataFrame after calculation.")
 
         df['signal'] = 'HOLD'
 
         # Find where the breakout/breakdown happened
         previous_close = df['close'].shift(1)
-        previous_upper_band = df['kc_upper'].shift(1)
-        previous_lower_band = df['kc_lower'].shift(1)
+        previous_upper_band = df[upper_band_col].shift(1)
+        previous_lower_band = df[lower_band_col].shift(1)
 
         # A BUY signal is generated on a close above the upper channel
-        buy_conditions = (df['close'] > df['kc_upper']) & (previous_close <= previous_upper_band)
+        buy_conditions = (df['close'] > df[upper_band_col]) & (previous_close <= previous_upper_band)
 
         # A SELL signal is generated on a close below the lower channel
-        sell_conditions = (df['close'] < df['kc_lower']) & (previous_close >= previous_lower_band)
+        sell_conditions = (df['close'] < df[lower_band_col]) & (previous_close >= previous_lower_band)
 
         df.loc[buy_conditions, 'signal'] = 'BUY'
         df.loc[sell_conditions, 'signal'] = 'SELL'

--- a/kost1ktrade/frontend/src/pages/StrategyManager.tsx
+++ b/kost1ktrade/frontend/src/pages/StrategyManager.tsx
@@ -8,6 +8,7 @@ type StrategyParams = { [key: string]: number | string };
 type StrategyInfo = {
   active: boolean;
   params: StrategyParams;
+  type: 'signal' | 'grid';
 };
 
 type StrategiesStatus = {
@@ -49,28 +50,49 @@ const StrategyManager = () => {
 
   const handleToggle = async (strategyName: string) => {
     const originalStrategies = { ...strategies };
-    const updatedStrategy = { ...strategies[strategyName], active: !strategies[strategyName].active };
-    setStrategies(prev => ({ ...prev, [strategyName]: updatedStrategy }));
+    const strategyInfo = strategies[strategyName];
+    const isStarting = !strategyInfo.active;
+
+    // Optimistically update UI
+    setStrategies(prev => ({
+        ...prev,
+        [strategyName]: { ...strategyInfo, active: isStarting }
+    }));
 
     try {
-      await axios.post('/api/strategies/status', { statuses: { [strategyName]: updatedStrategy.active } });
-      showFeedback('success', `${toTitleCase(strategyName)} status updated.`, `${strategyName}-toggle`);
-    } catch (error) {
-      console.error("Failed to update strategy status", error);
-      showFeedback('error', `Failed to update ${toTitleCase(strategyName)}.`, `${strategyName}-toggle`);
-      setStrategies(originalStrategies);
+        if (strategyInfo.type === 'grid') {
+            const endpoint = isStarting ? '/api/grid-bot/start' : '/api/grid-bot/stop';
+            // For grid bot, we might need to specify the mode, e.g., 'demo'
+            const payload = isStarting ? { mode: 'demo' } : {};
+            await axios.post(endpoint, payload);
+        } else {
+            await axios.post('/api/strategies/status', { statuses: { [strategyName]: isStarting } });
+        }
+        showFeedback('success', `${toTitleCase(strategyName)} status updated.`, `${strategyName}-toggle`);
+        // Refresh status from server to get the real state
+        fetchStrategyStatus();
+    } catch (error: any) {
+        console.error("Failed to update strategy status", error);
+        showFeedback('error', error.response?.data?.detail || `Failed to update ${toTitleCase(strategyName)}.`, `${strategyName}-toggle`);
+        setStrategies(originalStrategies); // Revert on error
     }
   };
 
   const handleParamChange = (strategyName: string, paramName: string, value: string) => {
     const isNumeric = !isNaN(Number(value)) && value !== '';
+    const strategyInfo = strategies[strategyName];
+
+    // For grid bot, handle symbol as text
+    const paramType = typeof strategyInfo.params[paramName];
+    const parsedValue = paramType === 'string' ? value : (isNumeric ? parseFloat(value) : value);
+
     setStrategies(prev => ({
         ...prev,
         [strategyName]: {
             ...prev[strategyName],
             params: {
                 ...prev[strategyName].params,
-                [paramName]: isNumeric ? parseFloat(value) : value,
+                [paramName]: parsedValue,
             }
         }
     }));
@@ -79,11 +101,15 @@ const StrategyManager = () => {
   const handleSaveParams = async (strategyName: string) => {
     const strategyConfig = strategies[strategyName];
     try {
-      await axios.post('/api/strategies/params', { name: strategyName, params: strategyConfig.params });
-      showFeedback('success', `Parameters for ${toTitleCase(strategyName)} saved!`, `${strategyName}-save`);
-    } catch (error) {
-      console.error("Failed to save params", error);
-      showFeedback('error', `Failed to save parameters for ${toTitleCase(strategyName)}.`, `${strategyName}-save`);
+        if (strategyConfig.type === 'grid') {
+            await axios.post('/api/grid-bot/settings', strategyConfig.params);
+        } else {
+            await axios.post('/api/strategies/params', { name: strategyName, params: strategyConfig.params });
+        }
+        showFeedback('success', `Parameters for ${toTitleCase(strategyName)} saved!`, `${strategyName}-save`);
+    } catch (error: any) {
+        console.error("Failed to save params", error);
+        showFeedback('error', error.response?.data?.detail || `Failed to save parameters.`, `${strategyName}-save`);
     }
   };
 
@@ -96,36 +122,89 @@ const StrategyManager = () => {
         <p>Loading strategies...</p>
       ) : (
         <div className="strategy-list-container">
-          {Object.entries(strategies).map(([name, info]) => (
-            <div key={name} className={`strategy-card ${info.active ? 'active' : ''}`}>
-              <div className="strategy-card-header">
-                <h3>{toTitleCase(name)}</h3>
-                <label className="switch">
-                  <input type="checkbox" checked={info.active} onChange={() => handleToggle(name)} />
-                  <span className="slider round"></span>
-                </label>
-              </div>
-              <div className="strategy-card-body">
-                <div className="params-form">
-                  {Object.entries(info.params).map(([param, value]) => (
-                    <div className="param-input-group" key={param}>
-                      <label>{toTitleCase(param)}</label>
-                      <input
-                        type="number"
-                        value={value}
-                        onChange={(e) => handleParamChange(name, param, e.target.value)}
-                        step="any"
-                      />
+          {Object.entries(strategies).map(([name, info]) => {
+            if (info.type === 'grid') {
+              // --- Grid Bot Card ---
+              return (
+                <div key={name} className={`strategy-card ${info.active ? 'active' : ''}`}>
+                  <div className="strategy-card-header">
+                    <h3>{toTitleCase(name)} Bot</h3>
+                    <span className={`status-pill status-${info.active ? 'active' : 'stopped'}`}>
+                      {info.active ? 'Active' : 'Stopped'}
+                    </span>
+                  </div>
+                  <div className="strategy-card-body">
+                    <div className="params-form">
+                      {Object.entries(info.params).map(([param, value]) => (
+                        <div className="param-input-group" key={param}>
+                          <label>{toTitleCase(param)}</label>
+                          <input
+                            type={typeof value === 'string' ? 'text' : 'number'}
+                            value={value}
+                            onChange={(e) => handleParamChange(name, param, e.target.value)}
+                            step="any"
+                          />
+                        </div>
+                      ))}
                     </div>
-                  ))}
+                    <div className="button-group">
+                      <button className="save-button" onClick={() => handleSaveParams(name)}>
+                        Save Settings
+                      </button>
+                       <button
+                        className="start-button"
+                        onClick={() => handleToggle(name)}
+                        disabled={info.active}
+                      >
+                        Start
+                      </button>
+                      <button
+                        className="stop-button"
+                        onClick={() => handleToggle(name)}
+                        disabled={!info.active}
+                      >
+                        Stop
+                      </button>
+                    </div>
+                    {feedback.id === `${name}-save` && <p className={`inline-feedback ${feedback.type}`}>{feedback.message}</p>}
+                     {feedback.id === `${name}-toggle` && <p className={`inline-feedback ${feedback.type}`}>{feedback.message}</p>}
+                  </div>
                 </div>
-                <button className="save-button" onClick={() => handleSaveParams(name)}>
-                  Save Parameters
-                </button>
-                {feedback.id === `${name}-save` && <p className={`inline-feedback ${feedback.type}`}>{feedback.message}</p>}
-              </div>
-            </div>
-          ))}
+              );
+            } else {
+              // --- Signal Strategy Card ---
+              return (
+                <div key={name} className={`strategy-card ${info.active ? 'active' : ''}`}>
+                  <div className="strategy-card-header">
+                    <h3>{toTitleCase(name)}</h3>
+                    <label className="switch">
+                      <input type="checkbox" checked={info.active} onChange={() => handleToggle(name)} />
+                      <span className="slider round"></span>
+                    </label>
+                  </div>
+                  <div className="strategy-card-body">
+                    <div className="params-form">
+                      {Object.entries(info.params).map(([param, value]) => (
+                        <div className="param-input-group" key={param}>
+                          <label>{toTitleCase(param)}</label>
+                          <input
+                            type="number"
+                            value={value}
+                            onChange={(e) => handleParamChange(name, param, e.target.value)}
+                            step="any"
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <button className="save-button" onClick={() => handleSaveParams(name)}>
+                      Save Parameters
+                    </button>
+                    {feedback.id === `${name}-save` && <p className={`inline-feedback ${feedback.type}`}>{feedback.message}</p>}
+                  </div>
+                </div>
+              );
+            }
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
This commit introduces a user interface for the Grid Bot and resolves several issues related to backtesting and trading logic.

Features:
- The Grid Bot is now displayed in the Strategy Manager UI.
- Users can configure the Grid Bot's settings (symbol, grid range, number of grids, and amount per grid) from the UI.
- The Grid Bot can be started and stopped from the UI.

Fixes:
- Resolved backtesting errors for the `ichimoku` and `keltner_channels` strategies by correctly handling the output from the `pandas-ta` library.
- Made the backtester more robust by handling `NaN` values in signals.
- Added detailed traceback logging to the simulation endpoint to improve debugging.
- Fixed a critical bug where the signal bot would always trade the first symbol in the settings list, instead of the one selected by the master controller.
- Standardized the symbol format to use `/` as a separator.