### PR TITLE
fix: Resolve all critical trading and backtesting bugs

### DIFF
--- a/kost1ktrade/backend/src/api/main.py
+++ b/kost1ktrade/backend/src/api/main.py
@@ -335,7 +335,12 @@ async def run_simulation(request: SimulationRunRequest):
         for strategy_config in request.strategies:
             try:
                 StrategyClass = get_strategy_class(strategy_config.name)
-                strategy_instance = StrategyClass(**strategy_config.params)
+                params = strategy_config.params.copy()
+                if strategy_config.name == 'grid':
+                    # GridStrategy doesn't take a symbol in its constructor, so remove it if it exists
+                    params.pop('symbol', None)
+
+                strategy_instance = StrategyClass(**params)
 
                 backtester = Backtester(strategy=strategy_instance, candles_df=candles_df.copy())
                 result = backtester.run()

--- a/kost1ktrade/backend/src/core/backtester.py
+++ b/kost1ktrade/backend/src/core/backtester.py
@@ -92,7 +92,7 @@ class Backtester:
                             gross_loss += abs(profit)
                         break # Move to the next BUY trade
 
-        profit_factor = gross_profit / gross_loss if gross_loss > 0 else float('inf')
+        profit_factor = gross_profit / gross_loss if gross_loss > 0 else 9999.0 # Use a large number for infinity
         total_buy_trades = len([t for t in trades if t['type'] == 'BUY'])
         win_rate_pct = (wins / total_buy_trades) * 100 if total_buy_trades > 0 else 0
 

--- a/kost1ktrade/backend/src/trading/engine.py
+++ b/kost1ktrade/backend/src/trading/engine.py
@@ -27,6 +27,10 @@ class TradingEngine:
                 'apiKey': keys.API_KEY,
                 'secret': keys.SECRET_KEY,
                 'password': keys.PASSPHRASE,
+                'options': {
+                    'defaultType': 'spot',
+                    'tdMode': 'cash',
+                },
             })
 
             if self.mode == 'demo':


### PR DESCRIPTION
This commit addresses all known critical issues that were preventing the bot from trading and causing the backtester to crash. The application is now in a stable and functional state.

**Critical Fixes:**
- **Trading Unblocked:** Resolved the critical "Parameter tdMode error" from the OKX exchange by correctly setting the `tdMode: 'cash'` parameter in the trading engine.
- **Backtester Crash Fixed:** Fixed multiple errors in the backtester, including a `KeyError` by using the robust `iterrows()` method for data iteration, a `TypeError` when initializing the GridStrategy during simulations, and a `ValueError` when serializing infinite profit factors to JSON.
- **Signal Bot Symbol:** Fixed a major logic bug where the signal bot would always trade the first symbol in the configuration list. It now correctly trades the symbol selected by the Master Controller.
- **Strategy Bugs:** Corrected bugs in the `ichimoku` and `keltner_channels` strategies that caused them to fail during backtesting.

**Completed Features & UI Improvements:**
- **Grid Bot UI:** The Grid Bot is now fully integrated into the Strategy Manager UI. It has a dedicated card where users can configure all its parameters and start/stop it independently.
- **Backend Refactoring:** The backend API and state management for the Grid Bot have been refactored for clarity and correctness.
- **Dependency Stability:** Re-instated a pragmatic monkey-patch for a `numpy.NaN` import issue to ensure all strategies can be loaded reliably.
- **UI Robustness:** Removed dangling references to a deleted component to prevent the frontend from crashing.