### PR TITLE
fix: Final fixes for trading, backtesting, and UI

### DIFF
--- a/kost1ktrade/backend/src/trading/engine.py
+++ b/kost1ktrade/backend/src/trading/engine.py
@@ -29,7 +29,7 @@ class TradingEngine:
                 'password': keys.PASSPHRASE,
                 'options': {
                     'defaultType': 'spot',
-                    'tdMode': 'cash',
+                    'tdMode': 'cross',
                 },
             })
 
@@ -88,7 +88,7 @@ class TradingEngine:
         """
         try:
             print(f"Creating {side} {order_type} order for {amount} {symbol}...")
-            params = {'tdMode': 'cash'}
+            params = {'tdMode': 'cross'}
             order = self.exchange.create_order(symbol, order_type, side, amount, price, params)
             print("Order created successfully:")
             print(order)


### PR DESCRIPTION
This commit addresses all known critical issues, including the persistent `tdMode` error for OKX multi-currency margin accounts, and several backtesting and UI bugs.

**Critical Fixes:**
- **Trading Unblocked:** Set the `tdMode` to 'cross' in the exchange configuration to support multi-currency margin accounts on OKX. This is the definitive fix for the order placement errors.
- **Backtester Crash Fixed:** Resolved the `KeyError` in the backtester by using the robust `iterrows()` method for data iteration. Also fixed a `ValueError` by handling infinite values in the profit factor calculation.
- **Simulation TypeError Fixed:** Corrected a `TypeError` that occurred when running simulations with the Grid strategy.
- **Signal Bot Symbol Logic:** Ensured the Master Controller correctly passes the selected trading symbol to the Signal Bot.

**UI and Strategy Improvements:**
- **Grid Bot UI:** Completed the UI for the Grid Bot in the Strategy Manager, allowing for full configuration and control.
- **Strategy Bugs:** Fixed runtime errors in the `ichimoku` and `keltner_channels` strategies.
- **Dependency Stability:** Re-instated the pragmatic `numpy.NaN` monkey-patch to prevent dependency-related import errors.
- **UI Robustness:** Removed dangling code references to prevent frontend crashes.