### PR TITLE
feat: Enable simultaneous multi-symbol grid trading

### DIFF
--- a/kost1ktrade/backend/scripts/test_grid_bot.py
+++ b/kost1ktrade/backend/scripts/test_grid_bot.py
@@ -1,42 +1,77 @@
 import time
 import sys
 import os
+import threading
 
 # Add project root to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from src.core.grid_bot_controller import start_grid_bot, stop_grid_bot
+from src.core.grid_bot_controller import start_grid_bot, stop_grid_bot, stop_all_grid_bots
+from src.core.bot_state import bot_state
 
-if __name__ == '__main__':
-    print("--- Grid Bot Controller Test ---")
+def run_test():
+    print("--- Multi-Grid Bot Controller Test ---")
 
-    grid_config = {
-        "grid_range_low": 50000.0,
-        "grid_range_high": 60000.0,
-        "num_grids": 10,
+    # Configurations for two different bots
+    configs = {
+        "BTC/USDT": {
+            "symbol": "BTC/USDT",
+            "grid_range_low": 60000.0,
+            "grid_range_high": 70000.0,
+            "num_grids": 10,
+            "amount_per_grid": 10, # in quote currency (USDT)
+        },
+        "SOL/USDT": {
+            "symbol": "SOL/USDT",
+            "grid_range_low": 150.0,
+            "grid_range_high": 200.0,
+            "num_grids": 10,
+            "amount_per_grid": 5, # in quote currency (USDT)
+        }
     }
 
     try:
-        print("Attempting to start grid bot in 'demo' mode...")
-        start_grid_bot(
-            mode='demo',
-            symbol='BTC/USDT',
-            grid_config=grid_config,
-            amount_per_grid=0.001
-        )
+        # --- Start Bots ---
+        print("\n--- Attempting to start multiple grid bots in 'demo' mode ---")
+        for symbol, config in configs.items():
+            try:
+                print(f"Starting bot for {symbol}...")
+                start_grid_bot(symbol=symbol, mode='demo', config=config)
+            except ValueError as e:
+                print(f"Caught expected error on startup for {symbol}: {e}")
 
-        # Let the bot run for a few cycles
-        print("\nBot running. Waiting for 10 seconds before stopping...")
-        time.sleep(10)
+        # Verify they are running
+        print(f"\nCurrent running bots: {list(bot_state.grid_bot_states.keys())}")
+        assert len(bot_state.grid_bot_threads) == 2, "Expected 2 bots to be running."
+        print("All bots started successfully.")
+
+        # Let the bots run for a few cycles
+        print("\nBots running. Waiting for 15 seconds...")
+        time.sleep(15)
 
     except Exception as e:
-        print(f"\nCaught expected error on startup: {e}")
+        print(f"\nAn unexpected error occurred during the test: {e}")
+        import traceback
+        traceback.print_exc()
 
     finally:
-        print("\nAttempting to stop grid bot...")
+        # --- Stop Bots ---
+        print("\n--- Attempting to stop all grid bots ---")
         try:
-            stop_grid_bot()
-        except ValueError as e:
-            print(f"Stop command failed as expected: {e}")
+            stop_all_grid_bots()
+            # Wait a moment for threads to clean up
+            time.sleep(5)
+            print(f"Bots stopped. Current running bots: {list(bot_state.grid_bot_states.keys())}")
+            assert len(bot_state.grid_bot_threads) == 0, "Expected all bots to be stopped."
+            print("All bots stopped successfully.")
+        except Exception as e:
+            print(f"An error occurred during stop_all_grid_bots: {e}")
+
 
     print("\n--- Test Complete ---")
+
+if __name__ == '__main__':
+    # This script is a direct test of the controller logic, not the API.
+    # It requires a running environment where ccxt can initialize the trading engine.
+    # Ensure you have network connectivity.
+    run_test()

--- a/kost1ktrade/backend/src/api/main.py
+++ b/kost1ktrade/backend/src/api/main.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import List
 from src.core.bot_state import bot_state
 from src.core.bot_controller import start_bot_loop, stop_bot_loop, signal_trading_loop
-from src.core.grid_bot_controller import start_grid_bot, stop_grid_bot, grid_trading_loop
+from src.core.grid_bot_controller import start_grid_bot, stop_grid_bot, stop_all_grid_bots
 from src.core.master_controller import start_master_bot, stop_master_bot, master_trading_loop
 from src.core.backtester import Backtester
 from src.core.strategy_loader import get_strategy_class
@@ -82,66 +82,72 @@ async def get_signal_bot_status():
 
 # --- Grid Bot Control ---
 
-class GridBotSettings(BaseModel):
+class GridBotConfig(BaseModel):
     symbol: str
     grid_range_low: float
     grid_range_high: float
     num_grids: int
     amount_per_grid: float
 
-class GridBotModeRequest(BaseModel):
+class GridBotStartRequest(BaseModel):
     mode: Literal['real', 'demo']
+    configs: List[GridBotConfig]
 
-@router.get("/grid-bot/settings", tags=["Grid Bot Control"])
-async def get_grid_bot_settings():
-    """
-    Returns the current settings for the Grid Bot.
-    """
-    return bot_state.grid_bot_config
-
-@router.post("/grid-bot/settings", tags=["Grid Bot Control"])
-async def set_grid_bot_settings(settings: GridBotSettings):
-    """
-    Updates the settings for the Grid Bot.
-    """
-    if bot_state.grid_bot_mode != 'stopped':
-        raise HTTPException(status_code=400, detail="Cannot change settings while the Grid Bot is running.")
-    bot_state.grid_bot_config = settings.dict()
-    return {"message": "Grid Bot settings updated successfully."}
-
+class GridBotStopRequest(BaseModel):
+    symbol: str
 
 @router.post("/grid-bot/start", tags=["Grid Bot Control"])
-async def start_grid_bot_endpoint(request: GridBotModeRequest, background_tasks: BackgroundTasks):
+async def start_grid_bots_endpoint(request: GridBotStartRequest):
     """
-    Starts the grid trading bot with the currently saved configuration.
-    The bot will run in a background task.
+    Starts one or more grid trading bots based on the provided configurations.
+    Each bot will run in its own background thread.
     """
-    try:
-        config = bot_state.grid_bot_config
-        start_grid_bot(mode=request.mode)
-        # Add the main loop to background tasks
-        background_tasks.add_task(grid_trading_loop)
-        return {"message": "Grid bot start process initiated."}
-    except (ValueError, ConnectionError) as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    started_bots = []
+    errors = {}
+    for config in request.configs:
+        try:
+            start_grid_bot(symbol=config.symbol, mode=request.mode, config=config.dict())
+            started_bots.append(config.symbol)
+        except (ValueError, ConnectionError) as e:
+            errors[config.symbol] = str(e)
+
+    if not started_bots:
+        raise HTTPException(status_code=400, detail={"message": "No bots could be started.", "errors": errors})
+
+    return {
+        "message": f"Successfully initiated start for {len(started_bots)} bot(s).",
+        "started": started_bots,
+        "errors": errors
+    }
 
 @router.post("/grid-bot/stop", tags=["Grid Bot Control"])
-async def stop_grid_bot_endpoint():
+async def stop_grid_bot_endpoint(request: GridBotStopRequest):
     """
-    Stops the grid trading bot.
+    Stops a specific grid trading bot by its symbol.
     """
     try:
-        response = stop_grid_bot()
+        response = stop_grid_bot(symbol=request.symbol)
         return {"message": response}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
+@router.post("/grid-bot/stop-all", tags=["Grid Bot Control"])
+async def stop_all_grid_bots_endpoint():
+    """
+    Stops all currently running grid trading bots.
+    """
+    try:
+        response = stop_all_grid_bots()
+        return {"message": response}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
 @router.get("/grid-bot/status", tags=["Grid Bot Control"])
 async def get_grid_bot_status():
     """
-    Returns the current status of the grid bot.
+    Returns the current status of all active and configured grid bots.
     """
-    return {"current_mode": bot_state.grid_bot_mode}
+    return bot_state.grid_bot_states
 
 
 # --- Master Bot Control ---
@@ -250,11 +256,17 @@ async def get_strategies_status():
             "type": "signal"
         }
 
-    # Add the Grid Bot as a special strategy type
+    # Add the Grid Bot's status as a special strategy type
+    # It's considered "active" if there is at least one running grid bot.
+    # The params will show all the configurations of running bots.
+    active_grid_bots = {
+        symbol: "running" for symbol, state in bot_state.grid_bot_states.items() if state == "running"
+    }
     response['grid'] = {
-        "params": bot_state.grid_bot_config,
-        "active": bot_state.grid_bot_mode != 'stopped',
-        "type": "grid"
+        "params": bot_state.grid_bot_configs,
+        "active": len(active_grid_bots) > 0,
+        "type": "grid",
+        "running_bots": active_grid_bots
     }
     return response
 

--- a/kost1ktrade/backend/src/core/bot_state.py
+++ b/kost1ktrade/backend/src/core/bot_state.py
@@ -39,18 +39,12 @@ class BotState:
         self.signal_bot_thread: Optional[threading.Thread] = None
         self.signal_bot_stop_event: threading.Event = threading.Event()
 
-        # State for the grid bot
-        self.grid_bot_mode: str = "stopped"
-        self.grid_bot_engine: Optional['TradingEngine'] = None
-        self.grid_bot_thread: Optional[threading.Thread] = None
-        self.grid_bot_stop_event: threading.Event = threading.Event()
-        self.grid_bot_config: Dict[str, Any] = {
-            "symbol": "ETH/USDT",
-            "grid_range_low": 1800,
-            "grid_range_high": 2200,
-            "num_grids": 10,
-            "amount_per_grid": 50, # This is in quote currency (e.g., USDT)
-        }
+        # State for MULTIPLE grid bots, keyed by symbol
+        self.grid_bot_configs: Dict[str, Dict[str, Any]] = {}
+        self.grid_bot_states: Dict[str, str] = {}  # 'running', 'stopped'
+        self.grid_bot_engines: Dict[str, Optional['TradingEngine']] = {}
+        self.grid_bot_threads: Dict[str, Optional[threading.Thread]] = {}
+        self.grid_bot_stop_events: Dict[str, threading.Event] = {}
 
         # State for the master controller
         self.master_bot_mode: str = "stopped"

--- a/kost1ktrade/backend/src/core/grid_bot_controller.py
+++ b/kost1ktrade/backend/src/core/grid_bot_controller.py
@@ -1,33 +1,31 @@
 import time
-import numpy as np
+import threading
+from typing import Dict, Any
 from src.core.bot_state import bot_state
 from src.trading.engine import TradingEngine
 from src.strategies.grid import GridStrategy
 
-def grid_trading_loop():
+def grid_trading_loop(symbol: str):
     """
-    The main loop for the grid trading bot.
+    The main loop for an individual grid trading bot, identified by its symbol.
     This function is intended to be run in a background task.
     """
-    if bot_state.grid_bot_mode == "stopped":
-        return
-
-    engine = bot_state.grid_bot_engine
-    config = bot_state.grid_bot_config
-
-    symbol = config['symbol']
-    amount_per_grid = config['amount_per_grid']
-    grid_config = {
-        "grid_range_low": config['grid_range_low'],
-        "grid_range_high": config['grid_range_high'],
-        "num_grids": config['num_grids'],
-    }
-    strategy = GridStrategy(**grid_config)
-
-    print(f"--- Background grid bot loop started for {symbol} ---")
-
     try:
-        while not bot_state.grid_bot_stop_event.is_set():
+        engine = bot_state.grid_bot_engines[symbol]
+        config = bot_state.grid_bot_configs[symbol]
+        stop_event = bot_state.grid_bot_stop_events[symbol]
+
+        amount_per_grid = config['amount_per_grid']
+        grid_config = {
+            "grid_range_low": config['grid_range_low'],
+            "grid_range_high": config['grid_range_high'],
+            "num_grids": config['num_grids'],
+        }
+        strategy = GridStrategy(**grid_config)
+
+        print(f"--- Background grid bot loop started for {symbol} ---")
+
+        while not stop_event.is_set():
             try:
                 print(f"({time.ctime()}) --- Grid Reconciliation Cycle for {symbol} ---")
 
@@ -36,77 +34,101 @@ def grid_trading_loop():
                 if not ticker or 'last' not in ticker:
                     raise ValueError(f"Could not fetch a valid ticker for {symbol}")
                 current_price = ticker['last']
-                print(f"Current Price: ${current_price:,.2f}")
+                print(f"Current Price for {symbol}: ${current_price:,.2f}")
 
                 open_orders = engine.fetch_open_orders(symbol)
                 open_order_prices = {order['price'] for order in open_orders}
-                print(f"Found {len(open_orders)} open orders.")
+                print(f"Found {len(open_orders)} open orders for {symbol}.")
 
-                # Determine which orders should exist
                 required_buy_prices = {level for level in ideal_levels if level < current_price}
                 required_sell_prices = {level for level in ideal_levels if level > current_price}
 
-                # Cancel extraneous orders
                 for order in open_orders:
                     price = order['price']
                     side = order['side']
                     required = required_buy_prices if side == 'buy' else required_sell_prices
                     if price not in required:
-                        print(f"Cancelling extraneous {side} order at ${price:,.2f}")
+                        print(f"Cancelling extraneous {side} order for {symbol} at ${price:,.2f}")
                         engine.cancel_order(order['id'], symbol)
 
-                # Place missing orders
                 for price in required_buy_prices:
                     if price not in open_order_prices:
-                        # Calculate amount in base currency from the quote currency amount
                         amount_to_buy = amount_per_grid / price
                         engine.create_order(symbol, 'limit', 'buy', amount_to_buy, price)
 
                 for price in required_sell_prices:
                     if price not in open_order_prices:
-                        # For selling, the amount is in the base currency, which we don't track per-grid level.
-                        # This assumes we sell a fixed amount of base currency, which needs re-evaluation.
-                        # For now, we will assume amount_per_grid for selling is also in quote currency for simplicity,
-                        # which means we need to calculate the base amount to sell.
                         amount_to_sell = amount_per_grid / price
                         engine.create_order(symbol, 'limit', 'sell', amount_to_sell, price)
 
-                print("Grid reconciliation cycle complete.")
-                bot_state.grid_bot_stop_event.wait(timeout=30)
+                print(f"Grid reconciliation cycle complete for {symbol}.")
+                stop_event.wait(timeout=30)
 
             except Exception as e:
-                print(f"An error occurred in the grid trading loop: {e}")
-                bot_state.grid_bot_stop_event.wait(timeout=60)
+                print(f"An error occurred in the grid trading loop for {symbol}: {e}")
+                stop_event.wait(timeout=60)
     finally:
-        print(f"--- Background grid bot loop stopping... ---")
-        if bot_state.grid_bot_engine:
-            print("Cleaning up all open grid orders...")
-            bot_state.grid_bot_engine.cancel_all_orders(symbol)
+        print(f"--- Background grid bot loop for {symbol} stopping... ---")
+        if symbol in bot_state.grid_bot_engines:
+            print(f"Cleaning up all open grid orders for {symbol}...")
+            bot_state.grid_bot_engines[symbol].cancel_all_orders(symbol)
 
-        bot_state.grid_bot_mode = "stopped"
-        bot_state.grid_bot_engine = None
+        # Clean up state for this specific bot
+        bot_state.grid_bot_states.pop(symbol, None)
+        bot_state.grid_bot_engines.pop(symbol, None)
+        bot_state.grid_bot_configs.pop(symbol, None)
+        bot_state.grid_bot_threads.pop(symbol, None)
+        bot_state.grid_bot_stop_events.pop(symbol, None)
+        print(f"State for {symbol} has been cleaned up.")
 
 
-def start_grid_bot(mode: str):
-    """Prepares the state for the grid bot to be started in a background task."""
-    if bot_state.grid_bot_mode != "stopped":
-        raise ValueError("Grid bot is already running.")
+def start_grid_bot(symbol: str, mode: str, config: Dict[str, Any]):
+    """Prepares and starts a grid bot for a specific symbol."""
+    if bot_state.grid_bot_states.get(symbol) == "running":
+        raise ValueError(f"Grid bot for {symbol} is already running.")
 
-    bot_state.grid_bot_stop_event.clear()
+    bot_state.grid_bot_configs[symbol] = config
+    bot_state.grid_bot_states[symbol] = "running"
+    bot_state.grid_bot_stop_events[symbol] = threading.Event()
 
     try:
-        bot_state.grid_bot_engine = TradingEngine(mode=mode)
-        bot_state.grid_bot_mode = mode
-        print(f"Grid bot state prepared for '{mode}' mode.")
+        bot_state.grid_bot_engines[symbol] = TradingEngine(mode=mode)
+        thread = threading.Thread(target=grid_trading_loop, args=(symbol,))
+        bot_state.grid_bot_threads[symbol] = thread
+        thread.start()
+        print(f"Grid bot for {symbol} started in '{mode}' mode.")
     except Exception as e:
-        bot_state.grid_bot_mode = "stopped"
+        bot_state.grid_bot_states[symbol] = "stopped"
         raise e
 
-def stop_grid_bot():
-    """Signals the background grid trading loop to stop."""
-    if bot_state.grid_bot_mode == "stopped":
-        raise ValueError("Grid bot is not running.")
+def stop_grid_bot(symbol: str):
+    """Signals a specific grid trading bot to stop."""
+    if bot_state.grid_bot_states.get(symbol) != "running":
+        raise ValueError(f"Grid bot for {symbol} is not running.")
 
-    print("Signaling grid bot to stop...")
-    bot_state.grid_bot_stop_event.set()
-    return "Stop signal sent. The grid bot will shut down after its current cycle."
+    print(f"Signaling grid bot for {symbol} to stop...")
+    stop_event = bot_state.grid_bot_stop_events.get(symbol)
+    if stop_event:
+        stop_event.set()
+
+    thread = bot_state.grid_bot_threads.get(symbol)
+    if thread:
+        thread.join(timeout=60) # Wait for the thread to finish
+        if thread.is_alive():
+            print(f"Warning: Grid bot thread for {symbol} did not stop in time.")
+
+    return f"Stop signal sent to grid bot for {symbol}."
+
+def stop_all_grid_bots():
+    """Stops all currently running grid bots."""
+    running_bots = list(bot_state.grid_bot_states.keys())
+    if not running_bots:
+        return "No grid bots are currently running."
+
+    print(f"Stopping all running grid bots: {running_bots}")
+    for symbol in running_bots:
+        try:
+            stop_grid_bot(symbol)
+        except ValueError as e:
+            print(f"Could not stop bot {symbol}: {e}") # Already stopped or state inconsistent
+    return "Stop signal sent to all running grid bots."


### PR DESCRIPTION
Refactor Grid Bot to support multiple simultaneous instances.

This major architectural change refactors the grid bot system from a single-instance model to a multi-instance model, allowing users to run multiple grid bots for different trading symbols concurrently.

Key changes:
- Modified `BotState` to use dictionaries keyed by symbol for storing grid bot configurations, states, threads, and trading engines.
- Reworked `GridBotController` to manage a pool of bot threads. The controller functions (`start`, `stop`) now operate on a per-symbol basis.
- Overhauled the FastAPI endpoints in `main.py`:
    - `POST /api/grid-bot/start` now accepts a list of configurations to launch multiple bots at once.
    - `POST /api/grid-bot/stop` now takes a symbol to stop a specific bot.
    - Added `POST /api/grid-bot/stop-all` for convenience.
    - Removed the now-redundant single-bot settings endpoints.
- Updated the `test_grid_bot.py` script to verify the new multi-bot functionality.