### PR TITLE
Refactor Grid Bot to Support Multiple Symbols

### DIFF
--- a/kost1ktrade/backend/src/api/main.py
+++ b/kost1ktrade/backend/src/api/main.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import List
 from src.core.bot_state import bot_state
 from src.core.bot_controller import start_bot_loop, stop_bot_loop, signal_trading_loop
-from src.core.grid_bot_controller import start_grid_bot, stop_grid_bot, grid_trading_loop
+from src.core.grid_bot_controller import start_grid_bot, stop_grid_bot, stop_all_grid_bots
 from src.core.master_controller import start_master_bot, stop_master_bot, master_trading_loop
 from src.core.backtester import Backtester
 from src.core.strategy_loader import get_strategy_class
@@ -82,66 +82,74 @@ async def get_signal_bot_status():
 
 # --- Grid Bot Control ---
 
-class GridBotSettings(BaseModel):
-    symbol: str
+class GridBotConfig(BaseModel):
     grid_range_low: float
     grid_range_high: float
     num_grids: int
     amount_per_grid: float
 
-class GridBotModeRequest(BaseModel):
+class GridBotStartRequest(BaseModel):
     mode: Literal['real', 'demo']
+    symbol: str
+    config: GridBotConfig
 
-@router.get("/grid-bot/settings", tags=["Grid Bot Control"])
-async def get_grid_bot_settings():
-    """
-    Returns the current settings for the Grid Bot.
-    """
-    return bot_state.grid_bot_config
+class GridBotStopRequest(BaseModel):
+    symbol: str
 
-@router.post("/grid-bot/settings", tags=["Grid Bot Control"])
-async def set_grid_bot_settings(settings: GridBotSettings):
+@router.get("/grid-bot/status", tags=["Grid Bot Control"])
+async def get_grid_bots_status():
     """
-    Updates the settings for the Grid Bot.
+    Returns the current status of all grid bots.
     """
-    if bot_state.grid_bot_mode != 'stopped':
-        raise HTTPException(status_code=400, detail="Cannot change settings while the Grid Bot is running.")
-    bot_state.grid_bot_config = settings.dict()
-    return {"message": "Grid Bot settings updated successfully."}
+    return {
+        "mode": bot_state.grid_bots_mode,
+        "active_grids": list(bot_state.grid_bot_configs.keys())
+    }
 
+@router.get("/grid-bot/configs", tags=["Grid Bot Control"])
+async def get_grid_bot_configs():
+    """
+    Returns the configurations for all currently active grid bots.
+    """
+    return bot_state.grid_bot_configs
 
 @router.post("/grid-bot/start", tags=["Grid Bot Control"])
-async def start_grid_bot_endpoint(request: GridBotModeRequest, background_tasks: BackgroundTasks):
+async def start_grid_bot_endpoint(request: GridBotStartRequest):
     """
-    Starts the grid trading bot with the currently saved configuration.
-    The bot will run in a background task.
+    Starts a grid trading bot for a specific symbol.
+    The bot will run in a background thread managed by the controller.
     """
     try:
-        config = bot_state.grid_bot_config
-        start_grid_bot(mode=request.mode)
-        # Add the main loop to background tasks
-        background_tasks.add_task(grid_trading_loop)
-        return {"message": "Grid bot start process initiated."}
+        response = start_grid_bot(
+            mode=request.mode,
+            symbol=request.symbol,
+            config=request.config.dict()
+        )
+        return {"message": response}
     except (ValueError, ConnectionError) as e:
         raise HTTPException(status_code=400, detail=str(e))
 
 @router.post("/grid-bot/stop", tags=["Grid Bot Control"])
-async def stop_grid_bot_endpoint():
+async def stop_grid_bot_endpoint(request: GridBotStopRequest):
     """
-    Stops the grid trading bot.
+    Stops the grid trading bot for a specific symbol.
     """
     try:
-        response = stop_grid_bot()
+        response = stop_grid_bot(symbol=request.symbol)
+        return {"message": response}
+    except (ValueError, RuntimeError) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@router.post("/grid-bot/stop-all", tags=["Grid Bot Control"])
+async def stop_all_grid_bots_endpoint():
+    """
+    Stops all running grid trading bots.
+    """
+    try:
+        response = stop_all_grid_bots()
         return {"message": response}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-
-@router.get("/grid-bot/status", tags=["Grid Bot Control"])
-async def get_grid_bot_status():
-    """
-    Returns the current status of the grid bot.
-    """
-    return {"current_mode": bot_state.grid_bot_mode}
 
 
 # --- Master Bot Control ---
@@ -250,10 +258,10 @@ async def get_strategies_status():
             "type": "signal"
         }
 
-    # Add the Grid Bot as a special strategy type
+    # Add the Grid Bot status as a special entry
     response['grid'] = {
-        "params": bot_state.grid_bot_config,
-        "active": bot_state.grid_bot_mode != 'stopped',
+        "params": bot_state.grid_bot_configs,  # Now returns all active grid configs
+        "active": bot_state.grid_bots_mode != 'stopped',
         "type": "grid"
     }
     return response

--- a/kost1ktrade/backend/src/core/bot_state.py
+++ b/kost1ktrade/backend/src/core/bot_state.py
@@ -40,17 +40,12 @@ class BotState:
         self.signal_bot_stop_event: threading.Event = threading.Event()
 
         # State for the grid bot
-        self.grid_bot_mode: str = "stopped"
-        self.grid_bot_engine: Optional['TradingEngine'] = None
-        self.grid_bot_thread: Optional[threading.Thread] = None
-        self.grid_bot_stop_event: threading.Event = threading.Event()
-        self.grid_bot_config: Dict[str, Any] = {
-            "symbol": "ETH/USDT",
-            "grid_range_low": 1800,
-            "grid_range_high": 2200,
-            "num_grids": 10,
-            "amount_per_grid": 50, # This is in quote currency (e.g., USDT)
-        }
+        self.grid_bots_mode: str = "stopped"  # A single mode ('real' or 'demo') for all grid bots
+        self.grid_bots_engine: Optional['TradingEngine'] = None
+        self.grid_bot_threads: Dict[str, threading.Thread] = {}
+        self.grid_bot_stop_events: Dict[str, threading.Event] = {}
+        # Holds the configuration for each active grid bot, keyed by symbol
+        self.grid_bot_configs: Dict[str, Dict[str, Any]] = {}
 
         # State for the master controller
         self.master_bot_mode: str = "stopped"

--- a/kost1ktrade/backend/src/core/grid_bot_controller.py
+++ b/kost1ktrade/backend/src/core/grid_bot_controller.py
@@ -1,21 +1,21 @@
 import time
-import numpy as np
+import threading
+from typing import Dict, Any
+
 from src.core.bot_state import bot_state
 from src.trading.engine import TradingEngine
 from src.strategies.grid import GridStrategy
 
-def grid_trading_loop():
+def _run_single_grid_loop(symbol: str, config: Dict[str, Any], stop_event: threading.Event):
     """
-    The main loop for the grid trading bot.
-    This function is intended to be run in a background task.
+    The main trading loop for a single grid bot instance.
+    This function runs in a dedicated background thread for one symbol.
     """
-    if bot_state.grid_bot_mode == "stopped":
+    engine = bot_state.grid_bots_engine
+    if not engine:
+        print(f"FATAL: Grid bot for {symbol} stopping because trading engine is not available.")
         return
 
-    engine = bot_state.grid_bot_engine
-    config = bot_state.grid_bot_config
-
-    symbol = config['symbol']
     amount_per_grid = config['amount_per_grid']
     grid_config = {
         "grid_range_low": config['grid_range_low'],
@@ -27,7 +27,7 @@ def grid_trading_loop():
     print(f"--- Background grid bot loop started for {symbol} ---")
 
     try:
-        while not bot_state.grid_bot_stop_event.is_set():
+        while not stop_event.is_set():
             try:
                 print(f"({time.ctime()}) --- Grid Reconciliation Cycle for {symbol} ---")
 
@@ -35,14 +35,15 @@ def grid_trading_loop():
                 ticker = engine.fetch_ticker(symbol)
                 if not ticker or 'last' not in ticker:
                     raise ValueError(f"Could not fetch a valid ticker for {symbol}")
+
                 current_price = ticker['last']
-                print(f"Current Price: ${current_price:,.2f}")
+                print(f"Current Price for {symbol}: ${current_price:,.2f}")
 
                 open_orders = engine.fetch_open_orders(symbol)
                 open_order_prices = {order['price'] for order in open_orders}
-                print(f"Found {len(open_orders)} open orders.")
+                print(f"Found {len(open_orders)} open orders for {symbol}.")
 
-                # Determine which orders should exist
+                # --- Reconciliation Logic ---
                 required_buy_prices = {level for level in ideal_levels if level < current_price}
                 required_sell_prices = {level for level in ideal_levels if level > current_price}
 
@@ -52,61 +53,103 @@ def grid_trading_loop():
                     side = order['side']
                     required = required_buy_prices if side == 'buy' else required_sell_prices
                     if price not in required:
-                        print(f"Cancelling extraneous {side} order at ${price:,.2f}")
+                        print(f"Cancelling extraneous {side} order for {symbol} at ${price:,.2f}")
                         engine.cancel_order(order['id'], symbol)
 
                 # Place missing orders
                 for price in required_buy_prices:
                     if price not in open_order_prices:
-                        # Calculate amount in base currency from the quote currency amount
                         amount_to_buy = amount_per_grid / price
                         engine.create_order(symbol, 'limit', 'buy', amount_to_buy, price)
 
                 for price in required_sell_prices:
                     if price not in open_order_prices:
-                        # For selling, the amount is in the base currency, which we don't track per-grid level.
-                        # This assumes we sell a fixed amount of base currency, which needs re-evaluation.
-                        # For now, we will assume amount_per_grid for selling is also in quote currency for simplicity,
-                        # which means we need to calculate the base amount to sell.
                         amount_to_sell = amount_per_grid / price
                         engine.create_order(symbol, 'limit', 'sell', amount_to_sell, price)
 
-                print("Grid reconciliation cycle complete.")
-                bot_state.grid_bot_stop_event.wait(timeout=30)
+                print(f"Grid reconciliation cycle for {symbol} complete.")
+                stop_event.wait(timeout=30)  # Use the symbol-specific event
 
             except Exception as e:
-                print(f"An error occurred in the grid trading loop: {e}")
-                bot_state.grid_bot_stop_event.wait(timeout=60)
+                print(f"An error occurred in the grid trading loop for {symbol}: {e}")
+                stop_event.wait(timeout=60)
+
     finally:
-        print(f"--- Background grid bot loop stopping... ---")
-        if bot_state.grid_bot_engine:
-            print("Cleaning up all open grid orders...")
-            bot_state.grid_bot_engine.cancel_all_orders(symbol)
+        print(f"--- Background grid bot loop for {symbol} stopping... ---")
+        if bot_state.grid_bots_engine:
+            print(f"Cleaning up all open grid orders for {symbol}...")
+            bot_state.grid_bots_engine.cancel_all_orders(symbol)
 
-        bot_state.grid_bot_mode = "stopped"
-        bot_state.grid_bot_engine = None
+        # Clean up this bot's state from the global dictionaries
+        bot_state.grid_bot_threads.pop(symbol, None)
+        bot_state.grid_bot_stop_events.pop(symbol, None)
+        bot_state.grid_bot_configs.pop(symbol, None)
+        print(f"State for {symbol} has been cleaned up.")
+
+        # If this was the last bot, clean up the global engine and mode
+        if not bot_state.grid_bot_threads:
+            print("All grid bots have stopped. Shutting down the grid trading engine.")
+            bot_state.grid_bots_engine = None
+            bot_state.grid_bots_mode = "stopped"
 
 
-def start_grid_bot(mode: str):
-    """Prepares the state for the grid bot to be started in a background task."""
-    if bot_state.grid_bot_mode != "stopped":
-        raise ValueError("Grid bot is already running.")
+def start_grid_bot(mode: str, symbol: str, config: Dict[str, Any]):
+    """
+    Starts a new grid bot for a specific symbol in a background thread.
+    """
+    if symbol in bot_state.grid_bot_threads:
+        raise ValueError(f"A grid bot for {symbol} is already running.")
 
-    bot_state.grid_bot_stop_event.clear()
+    # If this is the first grid bot, initialize the engine and set the mode
+    if not bot_state.grid_bots_engine:
+        print(f"This is the first grid bot. Initializing trading engine in '{mode}' mode.")
+        bot_state.grid_bots_engine = TradingEngine(mode=mode)
+        bot_state.grid_bots_mode = mode
+    # If an engine already exists, ensure the mode is consistent
+    elif bot_state.grid_bots_mode != mode:
+        raise ValueError(f"Cannot start a '{mode}' bot. Grid bots are already running in '{bot_state.grid_bots_mode}' mode.")
 
-    try:
-        bot_state.grid_bot_engine = TradingEngine(mode=mode)
-        bot_state.grid_bot_mode = mode
-        print(f"Grid bot state prepared for '{mode}' mode.")
-    except Exception as e:
-        bot_state.grid_bot_mode = "stopped"
-        raise e
+    # Create and store the state for the new bot
+    stop_event = threading.Event()
+    bot_state.grid_bot_stop_events[symbol] = stop_event
+    bot_state.grid_bot_configs[symbol] = config
 
-def stop_grid_bot():
-    """Signals the background grid trading loop to stop."""
-    if bot_state.grid_bot_mode == "stopped":
-        raise ValueError("Grid bot is not running.")
+    # Create and start the thread
+    thread = threading.Thread(target=_run_single_grid_loop, args=(symbol, config, stop_event))
+    bot_state.grid_bot_threads[symbol] = thread
+    thread.start()
 
-    print("Signaling grid bot to stop...")
-    bot_state.grid_bot_stop_event.set()
-    return "Stop signal sent. The grid bot will shut down after its current cycle."
+    print(f"Grid bot for {symbol} has been started in '{mode}' mode.")
+    return f"Grid bot for {symbol} started successfully."
+
+
+def stop_grid_bot(symbol: str):
+    """
+    Signals a specific grid trading bot to stop.
+    """
+    if symbol not in bot_state.grid_bot_threads:
+        raise ValueError(f"No running grid bot found for symbol {symbol}.")
+
+    print(f"Signaling grid bot for {symbol} to stop...")
+    stop_event = bot_state.grid_bot_stop_events.get(symbol)
+    if stop_event:
+        stop_event.set()
+        return f"Stop signal sent to grid bot for {symbol}."
+    else:
+        # This case should ideally not be reached if threads and events are managed correctly
+        raise RuntimeError(f"Could not find a stop event for {symbol} despite a thread existing.")
+
+def stop_all_grid_bots():
+    """
+    Signals all running grid trading bots to stop.
+    """
+    if not bot_state.grid_bot_threads:
+        return "No grid bots are currently running."
+
+    print("Signaling all grid bots to stop...")
+    # Create a copy of the keys to avoid issues with dictionary size changing during iteration
+    symbols = list(bot_state.grid_bot_threads.keys())
+    for symbol in symbols:
+        stop_grid_bot(symbol)
+
+    return f"Stop signal sent to {len(symbols)} grid bots."


### PR DESCRIPTION
This commit refactors the grid bot system to allow for multiple grid strategies to run concurrently for different trading symbols. The previous implementation was limited to a single, hardcoded symbol.

Key changes include:
- Modified `core/bot_state.py` to store grid bot configurations, threads, and stop events in dictionaries keyed by the trading symbol.
- Rewrote `core/grid_bot_controller.py` to manage multiple threads, with each thread running a grid bot for a specific symbol. Added functions for per-symbol start/stop and a global stop-all function.
- Updated the FastAPI endpoints in `api/main.py` to align with the new multi-bot architecture. The API now supports starting, stopping, and querying the status of individual grid bots.