### PR TITLE
fix(deps): Pin pandas-ta to v0.3.14b for Windows compatibility

### DIFF
--- a/kost1ktrade/backend/Pipfile
+++ b/kost1ktrade/backend/Pipfile
@@ -24,7 +24,7 @@ shap = "*"
 yfinance = "*"
 feedparser = "*"
 vaderSentiment = "*"
-pandas-ta = "*"
+pandas-ta = "==0.3.14b"
 pyarrow = "*"
 
 [dev-packages]


### PR DESCRIPTION
A recent update to `pandas-ta` (v0.4.67b0) introduced a dependency on the `posix` module, which is not available on Windows, causing a `ModuleNotFoundError`.

This change pins the version to the last known stable version, `0.3.14b`, to resolve the cross-platform issue.