### PR TITLE
fix(data): Address API limits and library warnings

### DIFF
--- a/kost1ktrade/backend/scripts/collect_all_data.py
+++ b/kost1ktrade/backend/scripts/collect_all_data.py
@@ -124,7 +124,7 @@ if __name__ == '__main__':
     parser.add_argument(
         "--days",
         type=int,
-        default=180, # Default to 180 days to avoid sandbox file size limits
+        default=90, # Default to 90 days to comply with OKX API limits and avoid sandbox issues
         help="Number of past days of history to collect."
     )
     args = parser.parse_args()

--- a/kost1ktrade/backend/src/data_collector/macro_collector.py
+++ b/kost1ktrade/backend/src/data_collector/macro_collector.py
@@ -25,7 +25,7 @@ class MacroDataCollector:
         print(f"Fetching macro data for tickers {list(self.tickers.values())} from {start_date} to {end_date}...")
         try:
             # Download data from yfinance
-            data = yf.download(list(self.tickers.values()), start=start_date, end=end_date, progress=False)
+            data = yf.download(list(self.tickers.values()), start=start_date, end=end_date, progress=False, auto_adjust=True)
 
             if data.empty:
                 print("Warning: No data returned from yfinance.")

--- a/kost1ktrade/backend/src/data_collector/sentiment_collector.py
+++ b/kost1ktrade/backend/src/data_collector/sentiment_collector.py
@@ -31,7 +31,7 @@ class SentimentCollector:
             df = pd.DataFrame(json_data['data'])
 
             # Convert 'timestamp' to datetime and set as index
-            df['timestamp'] = pd.to_datetime(df['timestamp'], unit='s')
+            df['timestamp'] = pd.to_datetime(pd.to_numeric(df['timestamp']), unit='s')
             df = df.set_index('timestamp').sort_index()
 
             # Convert 'value' to numeric


### PR DESCRIPTION
This commit applies several fixes to the data collection pipeline based on user feedback from running on a Windows machine.

1. Reduces the default data collection period in `collect_all_data.py` to 90 days. This is to work around an OKX API limit for fetching historical Open Interest data, which fails for longer periods.
2. Fixes a pandas `FutureWarning` in `sentiment_collector.py` by explicitly casting the timestamp column to a numeric type before converting to datetime.
3. Fixes a yfinance `FutureWarning` in `macro_collector.py` by explicitly setting `auto_adjust=True` in the download call.