### PR TITLE
fix: Correct backward pagination loop in data collector

### DIFF
--- a/kost1ktrade/backend/src/data_collector/collector.py
+++ b/kost1ktrade/backend/src/data_collector/collector.py
@@ -282,7 +282,8 @@ class DataCollector:
                     print("Timestamp did not advance backward. Breaking loop.")
                     break
 
-                current_until = oldest_ts_in_chunk
+                # Subtract 1ms to make the next request exclusive of the last record
+                current_until = oldest_ts_in_chunk - 1
 
                 # Be polite to the API
                 time.sleep(self.exchange.rateLimit / 1000)


### PR DESCRIPTION
The `fetch_paginated_history_backwards` function was getting stuck in a loop, repeatedly fetching the same chunk of data. This was because the `until` timestamp for the next request was not being updated correctly for APIs that use an inclusive `until` parameter.

This commit fixes the issue by subtracting 1 millisecond from the oldest timestamp of the fetched chunk before using it as the `until` parameter for the next iteration. This ensures the pagination correctly moves backward through the available history without refetching data.