### PR TITLE
fix: Make backward pagination logic robust

### DIFF
--- a/kost1ktrade/backend/src/data_collector/collector.py
+++ b/kost1ktrade/backend/src/data_collector/collector.py
@@ -271,14 +271,15 @@ class DataCollector:
                     print("No more data returned from exchange. Stopping backward pagination.")
                     break
 
-                # The data from the exchange is typically newest first.
+                # The data from the exchange can be in any order, so we find the minimum timestamp robustly.
                 all_data.extend(data_chunk)
 
-                oldest_ts_in_chunk = data_chunk[-1]['timestamp']
+                oldest_ts_in_chunk = min(d['timestamp'] for d in data_chunk)
                 print(f"  Fetched {len(data_chunk)} new data points, back to {datetime.datetime.fromtimestamp(oldest_ts_in_chunk/1000)}")
 
-                # If the oldest timestamp is the same as the one we requested, we are stuck.
-                if oldest_ts_in_chunk == current_until:
+                # If the oldest timestamp is the same as the one we requested (or older), we are stuck.
+                # The check should be against the new oldest timestamp.
+                if oldest_ts_in_chunk >= current_until:
                     print("Timestamp did not advance backward. Breaking loop.")
                     break
 


### PR DESCRIPTION
The `fetch_paginated_history_backwards` function was getting stuck in a loop. The previous fix assumed a newest-first sort order from the exchange, which was not always the case (e.g., for funding rates).

This commit makes the logic robust by explicitly finding the minimum timestamp in the fetched data chunk, rather than assuming the order of the elements. This ensures the pagination correctly moves backward through the available history for all data types, regardless of how the exchange API returns the data.