### PR TITLE
feat: Automate full pipeline for all symbols

### DIFF
--- a/kost1ktrade/README.md
+++ b/kost1ktrade/README.md
@@ -36,32 +36,16 @@ This step only needs to be performed once.
 
 This is the new core workflow. This process runs the entire quantitative analysis pipeline to produce the final, production-ready model that the live bot will use.
 
-**You should run this full sequence whenever you want to update the trading model.** All commands must be run from the `kost1ktrade/backend` directory.
+**You should run this script whenever you want to generate or update the trading models for all symbols configured in your `.env` file.**
 
+This single command will execute the entire quantitative pipeline (data collection, feature engineering, labeling, training, and saving) for all assets.
+
+From the `kost1ktrade/backend` directory, run:
 ```bash
-# 1. Collect all required data (e.g., for the last 30 days)
-pipenv run python scripts/collect_all_data.py --days 30
-
-# 2. Process the raw data to generate features
-pipenv run python scripts/process_features.py --asset BTC
-
-# 3. Apply labels to the feature set using the Triple-Barrier Method
-pipenv run python scripts/apply_labels.py --asset BTC
-
-# 4. Select the best features from the dataset
-pipenv run python scripts/select_features.py --asset BTC
-
-# 5. Run a walk-forward backtest for performance analysis
-pipenv run python scripts/run_backtest.py --asset BTC
-
-# 6. Evaluate the results of the backtest
-pipenv run python scripts/evaluate_model.py --asset BTC
-
-# 7. (CRITICAL STEP) Train and save the final production model
-pipenv run python scripts/create_production_model.py --asset BTC
+pipenv run python scripts/run_full_pipeline.py
 ```
 
-After this, a new model will be saved in the `kost1ktrade/backend/models/production/` directory. The bot will automatically find and use this model.
+After the script finishes, new production-ready models will be available in the `kost1ktrade/backend/models/production/` directory. The bot will automatically find and use these new models the next time it makes a prediction.
 
 ---
 

--- a/kost1ktrade/backend/scripts/run_full_pipeline.py
+++ b/kost1ktrade/backend/scripts/run_full_pipeline.py
@@ -1,0 +1,87 @@
+import subprocess
+import sys
+import os
+
+# Adjust the path to allow imports from the 'src' directory
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.core.config import settings
+from src.core.utils import parse_asset_from_symbol
+
+def run_command(command: list):
+    """Runs a command using subprocess and checks for errors."""
+    print(f"\n>>> Running command: {' '.join(command)}")
+    try:
+        # We use pipenv run to execute the scripts in the project's virtual environment
+        # The command passed to this function should be the python script and its args
+        full_command = ["pipenv", "run", "python"] + command
+        subprocess.run(full_command, check=True, text=True)
+    except subprocess.CalledProcessError as e:
+        print(f"\n---!!! SCRIPT FAILED: {' '.join(command)} !!!---")
+        print(f"---!!! Error: {e} !!!---")
+        # Re-raise the exception to stop the master script
+        raise
+    except FileNotFoundError:
+        print("\n---!!! ERROR: 'pipenv' command not found. !!!---")
+        print("---!!! Please ensure pipenv is installed and in your PATH. !!!---")
+        raise
+
+def main():
+    """
+    Main script to run the entire quantitative pipeline for all configured symbols.
+    """
+    print("======================================================")
+    print("===  STARTING FULL QUANTITATIVE PIPELINE FOR ALL   ===")
+    print("======================================================")
+
+    # Note: collect_all_data.py fetches for all symbols at once.
+    # It does not need to be in the loop.
+    pipeline_step_0 = [
+        "scripts/collect_all_data.py",
+        "--days", "30" # A reasonable default
+    ]
+
+    try:
+        run_command(pipeline_step_0)
+    except Exception as e:
+        print("\nFATAL: Data collection step failed. Cannot proceed.")
+        sys.exit(1)
+
+
+    # These scripts need to be run per-asset
+    for symbol in settings.SYMBOLS:
+        asset = parse_asset_from_symbol(symbol)
+        timeframe = settings.TIMEFRAME
+
+        print(f"\n================ PROCESSING ASSET: {asset} ================")
+
+        pipeline_steps = [
+            ["scripts/process_features.py", "--asset", asset, "--timeframe", timeframe],
+            ["scripts/apply_labels.py", "--asset", asset, "--timeframe", timeframe],
+            ["scripts/select_features.py", "--asset", asset, "--timeframe", timeframe],
+            ["scripts/run_backtest.py", "--asset", asset, "--timeframe", timeframe],
+            ["scripts/evaluate_model.py", "--asset", asset, "--timeframe", timeframe],
+            ["scripts/create_production_model.py", "--asset", asset, "--timeframe", timeframe],
+        ]
+
+        try:
+            for step_command in pipeline_steps:
+                run_command(step_command)
+            print(f"\n=== SUCCESSFULLY COMPLETED PIPELINE FOR {asset} ===")
+        except Exception as e:
+            print(f"\n---!!! PIPELINE FAILED FOR ASSET: {asset} !!!---")
+            # Ask user if they want to continue with the next asset
+            user_input = input(f"Do you want to continue with the next asset? (y/n): ").lower()
+            if user_input != 'y':
+                print("Aborting full pipeline run.")
+                sys.exit(1)
+            else:
+                continue # Go to the next symbol in the loop
+
+    print("\n======================================================")
+    print("===      FULL PIPELINE RUN COMPLETED             ===")
+    print("======================================================")
+
+
+if __name__ == "__main__":
+    main()

--- a/kost1ktrade/backend/src/core/utils.py
+++ b/kost1ktrade/backend/src/core/utils.py
@@ -1,0 +1,11 @@
+"""
+A collection of shared utility functions used across the application.
+"""
+
+def sanitize_symbol(symbol: str) -> str:
+    """Converts a symbol like 'BTC/USDT' to 'BTC_USDT' for filenames."""
+    return symbol.replace('/', '_')
+
+def parse_asset_from_symbol(symbol: str) -> str:
+    """Converts 'BTC/USDT' or 'BTC-USDT' to 'BTC'."""
+    return symbol.split('/')[0].split('-')[0]

--- a/kost1ktrade/backend/src/ml/predictor.py
+++ b/kost1ktrade/backend/src/ml/predictor.py
@@ -6,18 +6,11 @@ from typing import Dict, List, Any
 
 # Import global settings to access the timeframe
 from src.core.config import settings
+from src.core.utils import sanitize_symbol, parse_asset_from_symbol
 
 # --- Constants for model directories ---
 PROD_MODEL_DIR = "models/production"
 OLD_MODEL_DIR = "src/ml/models"
-
-def sanitize_symbol(symbol: str) -> str:
-    """Converts a symbol like 'BTC/USDT' to 'BTC_USDT' for filenames."""
-    return symbol.replace('/', '_')
-
-def parse_asset_from_symbol(symbol: str) -> str:
-    """Converts 'BTC/USDT' or 'BTC-USDT' to 'BTC'."""
-    return symbol.split('/')[0].split('-')[0]
 
 
 class Predictor:


### PR DESCRIPTION
This feature introduces a master script `run_full_pipeline.py` to fully automate the quantitative pipeline for all configured symbols.

Previously, the model generation pipeline required running multiple scripts for each asset manually. This was tedious and error-prone.

This change introduces a single entry point that:
- Reads the configured symbols from the settings.
- Executes the entire 7-step pipeline (from data collection to model creation) for each symbol in a loop.
- Provides robust error handling to stop or continue the process if a step fails for a particular asset.

The `create_production_model.py` script was reverted to its single-asset version to be callable by the master script. The documentation has been updated to reflect the new, much simpler workflow. A `utils.py` file was also created to centralize helper functions.