### PR TITLE
feat: Increase data collection period to 3 years

### DIFF
--- a/kost1ktrade/backend/scripts/run_full_pipeline.py
+++ b/kost1ktrade/backend/scripts/run_full_pipeline.py
@@ -38,7 +38,7 @@ def main():
     # It does not need to be in the loop.
     pipeline_step_0 = [
         "scripts/collect_all_data.py",
-        "--days", "30" # A reasonable default
+        "--days", "1095" # Set to 3 years
     ]
 
     try:


### PR DESCRIPTION
Updates the `run_full_pipeline.py` script to increase the data collection period from 30 days to 1095 days (approximately 3 years).

This provides the model with a much larger dataset for training and backtesting, which can improve its robustness and ability to learn from different market regimes.