### PR TITLE
fix: Improve network robustness and fix deprecation warning

### DIFF
--- a/kost1ktrade/backend/scripts/collect_all_data.py
+++ b/kost1ktrade/backend/scripts/collect_all_data.py
@@ -1,6 +1,6 @@
 import os
 import pandas as pd
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 import time
 import argparse
 import sys
@@ -32,7 +32,7 @@ def main(days_history: int):
 
     # Define date range
     # Using UTC for consistency with exchange times
-    end_date = datetime.utcnow() 
+    end_date = datetime.now(UTC)
     start_date = end_date - timedelta(days=days_history)
     start_date_str = start_date.strftime('%Y-%m-%d')
     end_date_str = end_date.strftime('%Y-%m-%d')

--- a/kost1ktrade/backend/src/data_collector/collector.py
+++ b/kost1ktrade/backend/src/data_collector/collector.py
@@ -36,6 +36,7 @@ class DataCollector:
     def fetch_candles(self, symbol: str, timeframe: str = '1h', since: int = None, limit: int = 100) -> List[list]:
         """
         Fetches historical OHLCV data for a given symbol.
+        (A) Includes retry logic for network robustness.
         :param symbol: The trading symbol (e.g., 'BTC/USDT').
         :param timeframe: The timeframe for the candles (e.g., '1m', '5m', '1h', '1d').
         :param since: The starting time in milliseconds since the epoch.
@@ -47,11 +48,19 @@ class DataCollector:
         if symbol not in self.exchange.markets:
             raise ValueError(f"Symbol '{symbol}' not available on {self.exchange.id}")
 
-        print(f"Fetching {limit} candles for {symbol} on timeframe {timeframe}...")
-        # CCXT returns data in a list of lists format: [timestamp, open, high, low, close, volume]
-        ohlcv = self.exchange.fetch_ohlcv(symbol, timeframe, since, limit)
-        # print(f"Fetched {len(ohlcv)} candles.") # This becomes too verbose in a loop
-        return ohlcv
+        # print(f"Fetching {limit} candles for {symbol} on timeframe {timeframe}...") # Becomes too verbose
+        retries = 3
+        for i in range(retries):
+            try:
+                # CCXT returns data in a list of lists format: [timestamp, open, high, low, close, volume]
+                ohlcv = self.exchange.fetch_ohlcv(symbol, timeframe, since, limit)
+                return ohlcv
+            except (ccxt.NetworkError, ccxt.ExchangeError) as e:
+                print(f"Attempt {i + 1}/{retries} for fetch_candles failed: {e}. Retrying in 5 seconds...")
+                time.sleep(5)
+
+        # If all retries fail, raise an exception to be handled by the calling function.
+        raise ExchangeError(f"Failed to fetch candles for {symbol} after {retries} retries.")
 
     def fetch_candles_in_range(self, symbol: str, timeframe: str, since: int, end: int) -> List[list]:
         """
@@ -160,7 +169,7 @@ class DataCollector:
     def fetch_funding_rate_history(self, symbol: str, since: int = None, limit: int = 100, params={}) -> List[dict]:
         """
         Fetches historical funding rate data for a given symbol.
-        OKX specific: uses fetch_funding_rate_history
+        (A) Includes retry logic for network robustness.
         :param symbol: The trading symbol (e.g., 'BTC-USDT-SWAP').
         :param since: The starting time in milliseconds since the epoch.
         :param limit: The number of candles to fetch. Max is 100 for this endpoint.
@@ -172,16 +181,23 @@ class DataCollector:
         if symbol not in self.exchange.markets:
             raise ValueError(f"Symbol '{symbol}' not available on {self.exchange.id}")
 
-        print(f"Fetching {limit} funding rates for {symbol}...")
-        # Note: CCXT unified method often returns in reverse chronological order (newest first)
-        funding_rates = self.exchange.fetch_funding_rate_history(symbol, since, limit, params)
-        # We REMOVE sorting to respect the exchange's default order, which is required for backward pagination.
-        return funding_rates
+        # print(f"Fetching {limit} funding rates for {symbol}...") # Becomes too verbose
+        retries = 3
+        for i in range(retries):
+            try:
+                funding_rates = self.exchange.fetch_funding_rate_history(symbol, since, limit, params)
+                return funding_rates
+            except (ccxt.NetworkError, ccxt.ExchangeError) as e:
+                print(f"Attempt {i + 1}/{retries} for fetch_funding_rate_history failed: {e}. Retrying in 5 seconds...")
+                time.sleep(5)
+
+        raise ExchangeError(f"Failed to fetch funding rates for {symbol} after {retries} retries.")
 
 
     def fetch_open_interest_history(self, symbol: str, timeframe: str = '1h', since: int = None, limit: int = 100, params={}) -> List[dict]:
         """
         Fetches historical open interest data for a given symbol.
+        (A) Includes retry logic for network robustness.
         :param symbol: The trading symbol (e.g., 'BTC-USDT-SWAP').
         :param timeframe: The timeframe for the data points (e.g., '5m', '1h', '4h', '1d').
         :param since: The starting time in milliseconds since the epoch.
@@ -194,10 +210,17 @@ class DataCollector:
         if symbol not in self.exchange.markets:
             raise ValueError(f"Symbol '{symbol}' not available on {self.exchange.id}")
 
-        print(f"Fetching {limit} open interest data points for {symbol} on timeframe {timeframe}...")
-        open_interest = self.exchange.fetch_open_interest_history(symbol, timeframe, since, limit, params)
-        # We REMOVE sorting to respect the exchange's default order, which is required for backward pagination.
-        return open_interest
+        # print(f"Fetching {limit} open interest data points for {symbol} on timeframe {timeframe}...") # Becomes too verbose
+        retries = 3
+        for i in range(retries):
+            try:
+                open_interest = self.exchange.fetch_open_interest_history(symbol, timeframe, since, limit, params)
+                return open_interest
+            except (ccxt.NetworkError, ccxt.ExchangeError) as e:
+                print(f"Attempt {i + 1}/{retries} for fetch_open_interest_history failed: {e}. Retrying in 5 seconds...")
+                time.sleep(5)
+
+        raise ExchangeError(f"Failed to fetch open interest for {symbol} after {retries} retries.")
 
 
 

--- a/kost1ktrade/backend/src/data_collector/sentiment_collector.py
+++ b/kost1ktrade/backend/src/data_collector/sentiment_collector.py
@@ -17,42 +17,53 @@ class SentimentCollector:
     def fetch_fear_greed_data(self, limit: int = 0) -> pd.DataFrame:
         """
         Fetches historical Fear & Greed Index data from alternative.me API.
+        (A) Includes retry logic for network robustness.
 
         :param limit: The number of days to fetch data for. 0 means all available data.
         :return: A pandas DataFrame with historical F&G data.
         """
         print(f"Fetching Fear & Greed Index data (limit={limit})...")
-        try:
-            url = f"https://api.alternative.me/fng/?limit={limit}"
-            response = requests.get(url, timeout=10)
-            response.raise_for_status()  # Raise an exception for bad status codes
+        retries = 3
+        for i in range(retries):
+            try:
+                url = f"https://api.alternative.me/fng/?limit={limit}"
+                response = requests.get(url, timeout=15)  # Increased timeout
+                response.raise_for_status()  # Raise an exception for bad status codes
 
-            json_data = response.json()
-            df = pd.DataFrame(json_data['data'])
+                json_data = response.json()
+                df = pd.DataFrame(json_data['data'])
 
-            # Convert 'timestamp' to datetime and set as index
-            df['timestamp'] = pd.to_datetime(pd.to_numeric(df['timestamp']), unit='s')
-            df = df.set_index('timestamp').sort_index()
+                # Convert 'timestamp' to datetime and set as index
+                df['timestamp'] = pd.to_datetime(pd.to_numeric(df['timestamp']), unit='s')
+                df = df.set_index('timestamp').sort_index()
 
-            # Convert 'value' to numeric
-            df['value'] = pd.to_numeric(df['value'])
+                # Convert 'value' to numeric
+                df['value'] = pd.to_numeric(df['value'])
 
-            # Rename columns for clarity
-            df = df.rename(columns={'value': 'fng_value', 'value_classification': 'fng_classification'})
+                # Rename columns for clarity
+                df = df.rename(columns={'value': 'fng_value', 'value_classification': 'fng_classification'})
 
-            # Drop the 'time_until_update' column as it's not needed for historical analysis
-            if 'time_until_update' in df.columns:
-                df = df.drop(columns=['time_until_update'])
+                # Drop the 'time_until_update' column as it's not needed for historical analysis
+                if 'time_until_update' in df.columns:
+                    df = df.drop(columns=['time_until_update'])
 
-            print(f"Successfully fetched {len(df)} F&G data points.")
-            return df
+                print(f"Successfully fetched {len(df)} F&G data points.")
+                return df
 
-        except requests.exceptions.RequestException as e:
-            print(f"An error occurred during API request to alternative.me: {e}")
-            return pd.DataFrame()
-        except Exception as e:
-            print(f"An error occurred while processing Fear & Greed data: {e}")
-            return pd.DataFrame()
+            except requests.exceptions.RequestException as e:
+                print(f"Attempt {i + 1}/{retries} failed: An error occurred during API request to alternative.me: {e}")
+                if i < retries - 1:
+                    print("Retrying in 5 seconds...")
+                    time.sleep(5)
+                else:
+                    print("All retries failed for Fear & Greed Index.")
+                    return pd.DataFrame()
+            except Exception as e:
+                print(f"A non-recoverable error occurred while processing Fear & Greed data: {e}")
+                # This is for JSON errors, etc. which are not worth retrying.
+                return pd.DataFrame()
+
+        return pd.DataFrame() # Should only be reached if the loop finishes, which it shouldn't
 
     def fetch_rss_news(self) -> list:
         """


### PR DESCRIPTION
This commit addresses two key issues to improve the stability and maintainability of the data collection pipeline.

1.  **Network Robustness:**
    - Adds retry logic (3 attempts with a 5-second delay) to all functions that make external network calls in `sentiment_collector.py` and `collector.py`.
    - This prevents the data collection process from failing due to temporary, transient errors from external APIs like the Fear & Greed Index or the OKX exchange.
    - The affected methods include `fetch_fear_greed_data`, `fetch_candles`, `fetch_funding_rate_history`, and `fetch_open_interest_history`.

2.  **Deprecation Warning Fix:**
    - Replaces the deprecated `datetime.utcnow()` call in `collect_all_data.py` with the recommended, timezone-aware `datetime.now(UTC)`.
    - This ensures future compatibility with upcoming Python versions.