### PR TITLE
fix: Make pipeline error handling non-interactive

### DIFF
--- a/kost1ktrade/backend/scripts/run_full_pipeline.py
+++ b/kost1ktrade/backend/scripts/run_full_pipeline.py
@@ -69,14 +69,11 @@ def main():
                 run_command(step_command)
             print(f"\n=== SUCCESSFULLY COMPLETED PIPELINE FOR {asset} ===")
         except Exception as e:
+            # (A) Do not ask for interactive input. Log the error and continue by default.
             print(f"\n---!!! PIPELINE FAILED FOR ASSET: {asset} !!!---")
-            # Ask user if they want to continue with the next asset
-            user_input = input(f"Do you want to continue with the next asset? (y/n): ").lower()
-            if user_input != 'y':
-                print("Aborting full pipeline run.")
-                sys.exit(1)
-            else:
-                continue # Go to the next symbol in the loop
+            print(f"---!!! Error was: {e} !!!---")
+            print(f"---!!! Continuing to the next asset. !!!---")
+            continue # Go to the next symbol in the loop
 
     print("\n======================================================")
     print("===      FULL PIPELINE RUN COMPLETED             ===")


### PR DESCRIPTION
Removes the interactive `input()` prompt from the main loop in `run_full_pipeline.py`.

Previously, if a single asset failed during processing, the script would halt and wait for user input, which is not suitable for automated execution.

Now, the script will log the error, print a message, and automatically continue to the next asset. This ensures that a failure on one asset does not stop the entire pipeline.