### PR TITLE
fix: Add missing sys.path append to pipeline script

### DIFF
--- a/kost1ktrade/backend/scripts/run_full_pipeline.py
+++ b/kost1ktrade/backend/scripts/run_full_pipeline.py
@@ -2,6 +2,10 @@ import subprocess
 import sys
 import os
 import multiprocessing
+
+# Adjust the path to allow imports from the 'src' directory
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from src.core.config import settings
 from src.core.utils import parse_asset_from_symbol
 


### PR DESCRIPTION
Restores the `sys.path.append` logic to `run_full_pipeline.py`.

This line was accidentally removed during a previous refactoring, which caused a `ModuleNotFoundError` because the script could no longer locate the `src` directory for imports.