### PR TITLE
Fix: Correct unterminated f-string in run_backtest.py

### DIFF
--- a/kost1ktrade/backend/scripts/run_backtest.py
+++ b/kost1ktrade/backend/scripts/run_backtest.py
@@ -349,11 +349,11 @@ def run_detailed_backtest(predictions: pd.DataFrame, asset: str, timeframe: str,
     if trades:
         print(f"  - Writing last 100 trades to {log_path}")
         with open(log_path, 'w', encoding='utf-8') as f:
-            f.write(f"--- Trade Log for {asset} ({timeframe}) ---
-")
-            f.write(f"--- Final Capital: ${capital:.2f} ---
+            f.write(f"""--- Trade Log for {asset} ({timeframe}) ---
+""")
+            f.write(f"""--- Final Capital: ${capital:.2f} ---
 
-")
+""")
 
             log_trades = trades[-100:]
             for i, trade in enumerate(log_trades):


### PR DESCRIPTION
The `run_detailed_backtest` function in `scripts/run_backtest.py` contained two multi-line f-strings that were not correctly enclosed in triple quotes. This resulted in a `SyntaxError: unterminated f-string literal` when the script was executed, causing the full data pipeline to fail for all assets.

This commit corrects the syntax by changing the single-quoted f-strings to triple-quoted f-strings, allowing them to span multiple lines. This resolves the error and allows the backtesting script to be parsed and executed correctly.