### PR TITLE
docs: Update documentation for PDM migration

### DIFF
--- a/kost1ktrade/AGENTS.md
+++ b/kost1ktrade/AGENTS.md
@@ -113,6 +113,11 @@ To use the external data features, you must set the following environment variab
         - **Confidence > 60%:** Risk 3% of capital.
     - This logic is currently implemented only in the backtesting script for evaluation purposes and is not yet part of the live trading bot.
 
+### 5. Dependency Tooling Migration (September 2025)
+- **Action:** Migrated the project's dependency management from `pipenv` to `pdm`.
+- **Reason:** The `pipenv` resolver was unable to handle complex dependency conflicts in the project's scientific stack, leading to a complete inability to install or update packages. The `pdm` resolver, along with its more detailed error reporting, successfully identified and resolved the issues.
+- **Critical Dependency Change:** The root cause of the dependency conflict was the `pandas-ta` package. Its only available version on PyPI requires `numpy>=2.2.6`, which is incompatible with the project's core requirement to use `numpy<2.0` (pinned at `1.26.4`). To create a stable environment, **`pandas-ta` has been removed from the project's dependencies.** Any functionality that relies on this package will need to be refactored or use an alternative, compatible library.
+
 ---
 
 ## Quantitative Analysis Pipeline (September 2025)

--- a/kost1ktrade/README.md
+++ b/kost1ktrade/README.md
@@ -11,9 +11,8 @@ This step only needs to be performed once.
 1.  **Install Dependencies:**
     *   **Backend (Python):** Navigate to the `kost1ktrade/backend` directory and run:
         ```bash
-        pipenv install
+        pdm install
         ```
-        *Note: If you encounter errors, you may need to manually install `matplotlib` by running `pipenv install matplotlib`.*
 
     *   **Frontend (JavaScript):** Navigate to the `kost1ktrade/frontend` directory and run:
         ```bash
@@ -27,7 +26,7 @@ This step only needs to be performed once.
 3.  **Initialize the Database:**
     *   From the `kost1ktrade/backend` directory, run the following command to create the database tables:
         ```bash
-        pipenv run python scripts/create_tables.py
+        pdm run python scripts/create_tables.py
         ```
 
 ---
@@ -42,7 +41,7 @@ This single command will execute the entire quantitative pipeline (data collecti
 
 From the `kost1ktrade/backend` directory, run:
 ```bash
-pipenv run python scripts/run_full_pipeline.py
+pdm run python scripts/run_full_pipeline.py
 ```
 
 After the script finishes, new production-ready models will be available in the `kost1ktrade/backend/models/production/` directory. The bot will automatically find and use these new models the next time it makes a prediction.
@@ -90,5 +89,5 @@ After running the `run_full_pipeline.py` script, two new log files are generated
 
 You can also run the backend and frontend in separate terminals for development.
 
-*   **Backend:** In `kost1ktrade/backend`, run `pipenv run uvicorn src.api.main:app --reload`
+*   **Backend:** In `kost1ktrade/backend`, run `pdm run uvicorn src.api.main:app --reload`
 *   **Frontend:** In `kost1ktrade/frontend`, run `npm run dev`


### PR DESCRIPTION
This commit updates the project's documentation to reflect the recent migration from `pipenv` to `pdm` for backend dependency management.

Changes:
- `kost1ktrade/README.md`: All setup, installation, and execution commands have been updated from `pipenv` to their `pdm` equivalents.
- `kost1ktrade/AGENTS.md`: Added a new entry under 'Recent Architectural Updates' to document the `pipenv` to `pdm` migration and to explicitly state that the `pandas-ta` package was removed due to an unsolvable dependency conflict. This provides critical context for future developers.