### PR TITLE
Fix(pipeline): Correct ETH data handling for feature generation

### DIFF
--- a/kost1ktrade/backend/scripts/process_features.py
+++ b/kost1ktrade/backend/scripts/process_features.py
@@ -51,7 +51,10 @@ def load_data_from_db(db: Session, asset: str, timeframe: str) -> dict:
     if not data['news'].empty: data['news'] = data['news'].rename(columns={'published_at': 'published'})
 
     # --- ETH Data for Correlation ---
-    if asset != 'ETH':
+    if asset == 'ETH':
+        print("  - Assigning ETH data for context (self-correlation)...")
+        data['eth_ohlcv'] = data['ohlcv'].copy()
+    else:
         print("  - Loading ETH data for context...")
         eth_symbol = "ETH/USDT:USDT"
         data['eth_ohlcv'] = pd.read_sql(db.query(Candle).filter(Candle.symbol == eth_symbol, Candle.interval == timeframe).statement, db.bind, index_col='open_time', parse_dates=['open_time'])


### PR DESCRIPTION
This commit addresses a `ValueError` in `run_backtest.py` that occurred when processing the ETH asset.

The root cause was that the feature generation process did not correctly handle the case where the asset being processed was ETH itself. The `eth_ohlcv` dataframe, used for correlation features, was not being populated. This led to an inconsistent feature set for ETH compared to other assets, causing downstream errors in the backtesting script.

The fix modifies `process_features.py` to ensure that `eth_ohlcv` is assigned a copy of the main `ohlcv` data when the processed asset is ETH. This ensures feature consistency across all assets.