### PR TITLE
Chore(pipeline): Harden ADF stationarity test

### DIFF
--- a/kost1ktrade/backend/src/processing/feature_generator.py
+++ b/kost1ktrade/backend/src/processing/feature_generator.py
@@ -385,7 +385,10 @@ class FeatureGenerator:
         Returns the p-value.
         """
         series = series.dropna()
-        if len(series) < 20:
+        # For adfuller with maxlag=48, we need nobs > 2 * (maxlag + 1), which is roughly 100.
+        # Let's use a safe buffer.
+        if len(series) < 101:
+            self._log(f"  -> Series has too few observations ({len(series)}) for ADF test with maxlag=48. Skipping.")
             return 0.0
         if series.nunique() < 2:
             self._log(f"  -> Series is constant. Marking as non-stationary.")


### PR DESCRIPTION
This commit improves the robustness of the Augmented Dickey-Fuller (ADF) test in the feature generation pipeline.

Previously, the test could fail with a `ValueError` if a feature series was too short for the hardcoded `maxlag=48` parameter. The error `maxlag must be less than (nobs/2 - 1 - ntrend)` occurred when this condition wasn't met.

The fix increases the minimum length check for the data series from 20 to 101 before the test is executed. This ensures the test only runs on series with sufficient data points, preventing the crash and making the pipeline more resilient.