### PR TITLE
Fix(pipeline): Make data collection and backtesting more robust

### DIFF
--- a/kost1ktrade/backend/scripts/collect_all_data.py
+++ b/kost1ktrade/backend/scripts/collect_all_data.py
@@ -88,15 +88,28 @@ def main(days_history: int):
                     since_ms = int((end_date - timedelta(days=days_history)).timestamp() * 1000)
                     print(f"No existing OHLCV data found. Starting full history download from {datetime.fromtimestamp(since_ms/1000).strftime('%Y-%m-%d %H:%M:%S')}.")
 
+                is_historical_fill = not latest_ohlcv_ms
+
                 if since_ms < int(end_date.timestamp() * 1000):
                     print(f"Fetching OHLCV data from {datetime.fromtimestamp(since_ms/1000).strftime('%Y-%m-%d %H:%M:%S')} to now...")
                     ohlcv_data = data_collector.fetch_candles_in_range(symbol, tf, since_ms, int(end_date.timestamp() * 1000))
+
+                    # (Fix) If a full history download fails, try a shorter period.
+                    if not ohlcv_data and is_historical_fill and days_history > 365:
+                        print(f"Warning: Full history download for {asset} ({tf}) with {days_history} days returned no data. Retrying with 365 days.")
+                        new_since_ms = int((end_date - timedelta(days=365)).timestamp() * 1000)
+                        ohlcv_data = data_collector.fetch_candles_in_range(symbol, tf, new_since_ms, int(end_date.timestamp() * 1000))
+
                     if ohlcv_data:
                         count = data_collector.save_candles_to_db(ohlcv_data, symbol, tf)
                         summary["crypto_specific"][asset][f"OHLCV ({tf})"] = count
                         print(f"-> Saved {count} new {tf} candles for {asset}.")
                     else:
-                        print("-> No new data returned from the exchange.")
+                        # Add a more prominent warning if the historical fill fails completely.
+                        if is_historical_fill:
+                            print(f"CRITICAL WARNING: Full history download for {asset} ({tf}) returned no data, even after retries. Downstream processes will likely fail.")
+                        else:
+                            print("-> No new data returned from the exchange.")
                 else:
                     print(f"OHLCV data for {asset} ({tf}) is already up to date.")
                 time.sleep(1)

--- a/kost1ktrade/backend/scripts/run_backtest.py
+++ b/kost1ktrade/backend/scripts/run_backtest.py
@@ -275,6 +275,10 @@ def run_detailed_backtest(predictions: pd.DataFrame, full_data: pd.DataFrame, as
     in_position = False
     current_trade = {}
 
+    # (Fix) Remove duplicate timestamps from predictions to prevent crash.
+    # The walk-forward validation can sometimes produce overlapping predictions.
+    predictions = predictions.loc[~predictions.index.duplicated(keep='first')]
+
     # --- Main Event Loop ---
     # We iterate through the predictions, which act as our entry signals.
     # We use the full_data dataframe to look ahead for exit conditions.


### PR DESCRIPTION
This commit addresses two critical failures in the quantitative pipeline:

1.  **Robust Data Collection:** The `collect_all_data.py` script would silently fail to gather data for certain assets (like ETH) if the exchange did not have deep historical data for the requested period (e.g., 3+ years). This resulted in empty dataframes and downstream failures. The script is now updated to retry with a shorter, 365-day history if the initial long-term fetch returns no data. This makes the data collection process more resilient to exchange-specific data limitations.

2.  **Stable Backtesting:** The `run_backtest.py` script was crashing with a `ValueError` for some assets (like SOL). This was caused by duplicate timestamps in the prediction data generated by the walk-forward validation, which broke the logic in the backtesting loop. A fix has been added to remove these duplicate timestamps before the simulation begins, preventing the crash and ensuring the backtest can run to completion.