### PR TITLE
Fix(backtest): Store position size as float to prevent TypeError

### DIFF
--- a/kost1ktrade/backend/scripts/run_backtest.py
+++ b/kost1ktrade/backend/scripts/run_backtest.py
@@ -402,7 +402,7 @@ def run_detailed_backtest(predictions: pd.DataFrame, full_data: pd.DataFrame, as
                     "stop_loss": entry_price - sl_distance if decision == 'BUY' else entry_price + sl_distance,
                     "take_profit": entry_price + tp_distance if decision == 'BUY' else entry_price - tp_distance,
                     "position_size_asset": position_size_asset,
-                    "position_size_usd": f"{position_size_usd:.2f}",
+                    "position_size_usd": position_size_usd,
                     "actual_amount_risked": actual_amount_risked,
                     "actual_amount_risked_usd": f"{actual_amount_risked:.2f}",
                     "reward_to_risk_ratio": tp_atr_mult / sl_atr_mult


### PR DESCRIPTION
This commit resolves a `TypeError` that occurred during the commission calculation in the backtesting simulation. The error was caused by the `position_size_usd` value being stored as a formatted string in the `current_trade` dictionary, rather than as a raw numeric type.

The fix changes the `current_trade` dictionary to store the `position_size_usd` as a float. This ensures that subsequent mathematical operations, such as the commission calculation, are performed on a numeric type, preventing the `TypeError` and allowing the backtest to complete successfully.