### PR TITLE
Fix(backtest): Store entry_price as float to prevent UFuncNoLoopError

### DIFF
--- a/kost1ktrade/backend/scripts/run_backtest.py
+++ b/kost1ktrade/backend/scripts/run_backtest.py
@@ -398,7 +398,7 @@ def run_detailed_backtest(predictions: pd.DataFrame, full_data: pd.DataFrame, as
                     "decision": decision,
                     "confidence": f"{confidence:.2%}",
                     "risk_percentage": f"{risk_percentage:.3%}",
-                    "entry_price": f"{entry_price:.4f}",
+                    "entry_price": entry_price,
                     "stop_loss": entry_price - sl_distance if decision == 'BUY' else entry_price + sl_distance,
                     "take_profit": entry_price + tp_distance if decision == 'BUY' else entry_price - tp_distance,
                     "position_size_asset": position_size_asset,


### PR DESCRIPTION
This commit resolves a `UFuncNoLoopError` that occurred during the PnL calculation in the backtesting simulation. The error was caused by the `entry_price` value being stored as a formatted string in the `current_trade` dictionary, which is incompatible with the numeric `exit_price` during subtraction.

The fix changes the `current_trade` dictionary to store the `entry_price` as a raw float. This ensures that all subsequent mathematical operations are performed on numeric types, preventing the crash and allowing the backtest to complete successfully. This is the second fix of this nature, improving the robustness of the backtesting logic.