### PR TITLE
Fix: Prevent deletion of EMA_200 column

### DIFF
--- a/kost1ktrade/backend/src/processing/feature_generator.py
+++ b/kost1ktrade/backend/src/processing/feature_generator.py
@@ -372,7 +372,7 @@ class FeatureGenerator:
 
     def check_and_transform_stationarity(self):
         self._log("\n[Bonus Step] Checking for Feature Stationarity")
-        exclude_cols = ['open', 'high', 'low', 'close', 'volume']
+        exclude_cols = ['open', 'high', 'low', 'close', 'volume', 'EMA_200']
         for col in self.df.columns.copy():
             if col not in exclude_cols and pd.api.types.is_numeric_dtype(self.df[col]):
                 p_value = self.test_stationarity(self.df[col])


### PR DESCRIPTION
The `check_and_transform_stationarity` method in the `FeatureGenerator` was deleting the `EMA_200` column after creating a stationarized version of it.

This caused an issue in the backtesting script, which relies on the original `EMA_200` column for trend filtering.

This change adds `EMA_200` to the `exclude_cols` list in the `check_and_transform_stationarity` method, so that this column is no longer deleted.