### PR TITLE
Fix(pipeline): Add data directory reset and correct OKX API call

### DIFF
--- a/kost1ktrade/backend/scripts/run_full_pipeline.py
+++ b/kost1ktrade/backend/scripts/run_full_pipeline.py
@@ -4,6 +4,7 @@ import os
 import multiprocessing
 import threading
 from io import StringIO
+import shutil
 
 # Adjust the path to allow imports from the 'src' directory
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -118,9 +119,32 @@ def main():
     print("===  STARTING FULL QUANTITATIVE PIPELINE           ===")
     print("======================================================")
 
+    BASE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+
+    # --- Data Directory Reset ---
+    print("\n--- Resetting Data Directory ---")
+    DATA_DIR = os.path.join(BASE_DIR, 'data')
+    if os.path.exists(DATA_DIR):
+        print(f"Deleting existing data directory: {DATA_DIR}")
+        try:
+            shutil.rmtree(DATA_DIR)
+            print("-> Successfully removed data directory.")
+        except Exception as e:
+            print(f"---!!! FAILED to delete data directory: {e} !!!---")
+            sys.exit(1)
+
+    print(f"Creating new data directory: {DATA_DIR}")
+    try:
+        os.makedirs(DATA_DIR, exist_ok=True)
+        print("-> Successfully created data directory.")
+    except Exception as e:
+        print(f"---!!! FAILED to create data directory: {e} !!!---")
+        sys.exit(1)
+    print("--- Data directory reset complete ---")
+
+
     # --- Log File Management ---
     print("\n--- Preparing Logs ---")
-    BASE_DIR = os.path.join(os.path.dirname(__file__), '..')
     FULL_LOG_PATH = os.path.join(BASE_DIR, 'full_log.txt')
 
     # Clear the main pipeline log

--- a/kost1ktrade/backend/src/data_collector/calendar_data.py
+++ b/kost1ktrade/backend/src/data_collector/calendar_data.py
@@ -20,14 +20,13 @@ def fetch_and_store_economic_calendar(data_collector: DataCollector, countries: 
     country_str = ",".join(countries)
 
     # ccxt requires the path for the implicit API call
-    path = 'api/v5/public/economic-calendar'
     params = {'country': country_str}
 
     all_events = []
     try:
-        # Use the authenticated fetch method from the existing DataCollector instance
+        # Use the ccxt implicit method to fetch from the public endpoint
         # This will automatically handle signing and headers
-        data = data_collector.exchange.fetch(path, 'public', 'GET', params)
+        data = data_collector.exchange.publicGetEconomicCalendar(params)
 
         # The OKX API nests the actual data inside a 'data' key and another list
         events = data.get('data', [])


### PR DESCRIPTION
This commit addresses two issues in the main pipeline:

1.  **Data Directory Reset:** The `run_full_pipeline.py` script now deletes and recreates the `kost1ktrade/backend/data` directory at the start of each run. This ensures a clean slate for each execution, preventing stale data from interfering with the results.

2.  **OKX API Fix:** The economic calendar data collection in `calendar_data.py` was failing due to an incorrect `ccxt` API call. The generic `fetch()` method has been replaced with the specific `publicGetEconomicCalendar()` implicit method, which is the correct and stable way to fetch this data from the OKX v5 API. This resolves the `'str' object has no attribute 'update'` error.