### PR TITLE
Fix(pipeline): Reset output directories and correct OKX API call

### DIFF
--- a/kost1ktrade/backend/src/data_collector/calendar_data.py
+++ b/kost1ktrade/backend/src/data_collector/calendar_data.py
@@ -19,14 +19,14 @@ def fetch_and_store_economic_calendar(data_collector: DataCollector, countries: 
 
     country_str = ",".join(countries)
 
-    # ccxt requires the path for the implicit API call
+    # Use the generic 'request' method for endpoints not explicitly defined in ccxt
+    path = 'api/v5/public/economic-calendar'
     params = {'country': country_str}
 
     all_events = []
     try:
-        # Use the ccxt implicit method to fetch from the public endpoint
-        # This will automatically handle signing and headers
-        data = data_collector.exchange.publicGetEconomicCalendar(params)
+        # This will automatically handle signing and headers via the collector's ccxt instance
+        data = data_collector.exchange.request(path, 'public', 'GET', params)
 
         # The OKX API nests the actual data inside a 'data' key and another list
         events = data.get('data', [])


### PR DESCRIPTION
This commit addresses two issues in the main pipeline:

1.  **Output Directory Reset:** The `run_full_pipeline.py` script now deletes and recreates the `data`, `reports`, and `models` directories at the start of each run. This ensures a clean slate for each execution, preventing stale data or artifacts from interfering with the results.

2.  **OKX API Fix:** The economic calendar data collection in `calendar_data.py` was failing. The fix involves using the `ccxt` library's generic `request` method to call the `api/v5/public/economic-calendar` endpoint. This is the correct and robust way to interact with endpoints that do not have a dedicated high-level method in the library, and it resolves the errors encountered during previous attempts.