### PR TITLE
Fix(pipeline): Reset directories and correct OKX API path

### DIFF
--- a/kost1ktrade/backend/src/data_collector/calendar_data.py
+++ b/kost1ktrade/backend/src/data_collector/calendar_data.py
@@ -20,7 +20,7 @@ def fetch_and_store_economic_calendar(data_collector: DataCollector, countries: 
     country_str = ",".join(countries)
 
     # Use the generic 'request' method for endpoints not explicitly defined in ccxt
-    path = 'api/v5/public/economic-calendar'
+    path = 'public/economic-calendar'
     params = {'country': country_str}
 
     all_events = []


### PR DESCRIPTION
This commit implements two key improvements to the data pipeline script:

1.  **Full Directory Reset:** The `run_full_pipeline.py` script now completely resets the `data`, `reports`, and `models` directories at the start of each execution. This ensures a clean, predictable environment for every pipeline run, preventing stale data or model artifacts from causing issues.

2.  **OKX Economic Calendar API Fix:** The data collection from the OKX API was failing due to an incorrect URL. The path provided to the `ccxt` library was wrong, causing a `404 Not Found` error. This has been corrected by changing the path from `api/v5/public/economic-calendar` to `public/economic-calendar`. This prevents the `api/v5/` prefix from being duplicated in the final URL.