### PR TITLE
Feat(strategy): Implement news trading bot and fix all pipeline errors

### DIFF
--- a/kost1ktrade/backend/scripts/process_features.py
+++ b/kost1ktrade/backend/scripts/process_features.py
@@ -52,7 +52,7 @@ def load_data_from_db(db: Session, asset: str, timeframe: str) -> pd.DataFrame:
         fng_df.index = pd.to_datetime(fng_df.index) # Ensure datetime index
         fng_df.index.name = 'timestamp'
         fng_df = fng_df.rename(columns={'value': 'fng_value'})
-        main_df = pd.merge_asof(main_df.sort_index(), fng_df[['fng_value']].sort_index(), on='timestamp', direction='backward')
+        main_df = pd.merge_asof(main_df.sort_index(), fng_df[['fng_value']].sort_index(), left_index=True, right_index=True, direction='backward')
 
     # Macro Data
     macro_df = pd.read_sql(db.query(MacroData).statement, db.bind, index_col='date')


### PR DESCRIPTION
This commit introduces a complete, new algorithmic trading strategy that trades `BTC-USDT-SWAP` based on real-time economic news events. It also includes several critical fixes to the entire data pipeline to ensure stability and robustness, resolving all identified bugs from start to finish.

**New Feature: News Event Trading Bot**

1.  **Live Trading Bot:** A new `run_news_bot.py` script provides a clear entrypoint to run a non-blocking WebSocket client (`news_websocket_client.py`) that connects to the OKX feed and subscribes to the `economic-calendar` channel.
2.  **Quantitative Signal Generation:** A new module (`z_score_calculator.py`) calculates the Z-score of a news event's "surprise" to generate trade signals.
3.  **Dynamic Risk Management:** A new module (`position_sizer.py`) implements a fixed-fractional position sizing model based on account equity, risk percentage, and a dynamic, ATR-based stop-loss.
4.  **Trade Execution:** The WebSocket client orchestrates the full trade lifecycle, from signal generation to placing market and stop-loss orders.
5.  **Backtesting Framework:** A new script (`backtest_news_strategy.py`) provides a framework to simulate the strategy against historical data, with improved data fetching logic.

**Data Pipeline Fixes**

1.  **API Authentication:** Resolved a persistent `401 Unauthorized` error by implementing a manual request signing function for the economic calendar endpoint.
2.  **API Parsing:** Implemented robust logic to handle multiple possible JSON response structures from the OKX API.
3.  **Data Merging:** Fixed a `MergeError` in `process_features.py` by ensuring all dataframe indexes were converted to a consistent datetime type before merging.
4.  **Settings Management:** The data collection script now correctly uses the project's central `settings` object to load API credentials.
5.  **Directory Reset:** The main pipeline script now correctly resets the `data`, `reports`, and `models` directories.