### PR TITLE
Fix(ml): Correct feature generation and handle NaN values

### DIFF
--- a/kost1ktrade/backend/src/ml/feature_generator.py
+++ b/kost1ktrade/backend/src/ml/feature_generator.py
@@ -39,6 +39,10 @@ def create_features(df: pd.DataFrame) -> pd.DataFrame:
     print("Generating a rich set of TA features (using TA-Lib)...")
 
     df_feat = df.copy()
+    # Ensure we have a DatetimeIndex for time-based features like VWAP
+    if 'open_time' in df_feat.columns and pd.api.types.is_datetime64_any_dtype(df_feat['open_time']):
+        df_feat.set_index('open_time', inplace=True)
+
     df_feat['log_returns'] = np.log(df_feat['close']).diff()
 
     open_p, high, low, close, volume = df_feat['open'].values, df_feat['high'].values, df_feat['low'].values, df_feat['close'].values, df_feat['volume'].values
@@ -108,6 +112,10 @@ def create_features(df: pd.DataFrame) -> pd.DataFrame:
     # Add return features for labeling/analysis if needed later
     for n in [1, 2, 4, 8, 16]:
         df_feat[f'return_{n}h'] = df_feat['close'].pct_change(n)
+
+    # Fill any remaining NaNs with 0 before returning
+    # This is a simple but effective way to ensure models don't get NaN inputs
+    df_feat.fillna(0, inplace=True)
 
     print(f"Feature generation complete. New shape: {df_feat.shape}")
 


### PR DESCRIPTION
This commit addresses two issues in the feature generation script (`src/ml/feature_generator.py`):

1.  **Fixed `dist_from_vwap_norm` Calculation:** The VWAP feature was previously failing because the function was called on a DataFrame without a `DatetimeIndex`. The script now ensures the index is set correctly before any time-based features are calculated, allowing VWAP to be computed as intended.

2.  **Imputed Missing Values:** The script now fills all remaining `NaN` values with `0` after feature generation. This prevents `RuntimeWarning`s during model training and ensures the model receives clean, complete data.