### PR TITLE
Fix(ml): Resolve KeyError by resetting index in feature generator

### DIFF
--- a/kost1ktrade/backend/src/ml/feature_generator.py
+++ b/kost1ktrade/backend/src/ml/feature_generator.py
@@ -117,6 +117,9 @@ def create_features(df: pd.DataFrame) -> pd.DataFrame:
     # This is a simple but effective way to ensure models don't get NaN inputs
     df_feat.fillna(0, inplace=True)
 
+    # Reset index to turn 'open_time' back into a column for the calling script
+    df_feat.reset_index(inplace=True)
+
     print(f"Feature generation complete. New shape: {df_feat.shape}")
 
     return df_feat


### PR DESCRIPTION
This commit fixes a `KeyError: 'open_time'` that occurred in `scripts/process_features.py`.

The error was caused by a conflict between the feature generation function and the calling script. The `create_features` function was setting `open_time` as the index but was not converting it back to a column before returning the DataFrame. The calling script then failed when it tried to access the `open_time` column to set the index again.

This has been resolved by adding a `reset_index()` call at the end of the `create_features` function. This makes the function's behavior consistent with the expectations of the calling script.