### PR TITLE
Fix(ml): Restore cyclical time-based features

### DIFF
--- a/kost1ktrade/backend/src/ml/feature_generator.py
+++ b/kost1ktrade/backend/src/ml/feature_generator.py
@@ -82,9 +82,10 @@ def create_features(df: pd.DataFrame) -> pd.DataFrame:
 
     # --- NEW: Cyclical Time-Based Features ---
     print("Adding cyclical time-based features...")
-    if 'open_time' in df_feat.columns and pd.api.types.is_datetime64_any_dtype(df_feat['open_time']):
-        hour = df_feat['open_time'].dt.hour
-        day_of_week = df_feat['open_time'].dt.dayofweek
+    # The index should be datetime at this point due to the fix at the start of the function.
+    if isinstance(df_feat.index, pd.DatetimeIndex):
+        hour = df_feat.index.hour
+        day_of_week = df_feat.index.dayofweek
         df_feat['hour_sin'] = np.sin(2 * np.pi * hour / 24)
         df_feat['hour_cos'] = np.cos(2 * np.pi * hour / 24)
         df_feat['day_of_week_sin'] = np.sin(2 * np.pi * day_of_week / 7)


### PR DESCRIPTION
This commit fixes a bug where the cyclical time-based features (e.g., `hour_sin`, `day_of_week_sin`) were not being generated.

The issue was caused by a previous change that set `open_time` as the DataFrame index. The subsequent code block that generated the cyclical features was still checking for `open_time` as a column, causing it to be skipped.

The logic has now been made more robust. It calculates the cyclical features directly from the `DatetimeIndex`, ensuring they are always included in the final feature set.