### PR TITLE
Feat(ml): Enable GPU acceleration for XGBoost training

### DIFF
--- a/kost1ktrade/backend/scripts/train_xgboost_model.py
+++ b/kost1ktrade/backend/scripts/train_xgboost_model.py
@@ -57,6 +57,7 @@ def optimize_hyperparameters_xgb(X_train, y_train, n_trials=50):
             'gamma': trial.suggest_float('gamma', 1e-7, 1.0, log=True),
             'lambda': trial.suggest_float('lambda', 1e-7, 1.0, log=True),  # L2 regularization
             'alpha': trial.suggest_float('alpha', 1e-7, 1.0, log=True),   # L1 regularization
+            'tree_method': 'gpu_hist',  # Use GPU for training
             'random_state': 42,
             'n_jobs': -1
         }
@@ -149,6 +150,7 @@ def train_xgboost_model(symbol: str, timeframe: str):
         num_class=3,
         eval_metric='mlogloss',
         random_state=42,
+        tree_method='gpu_hist',  # Use GPU for training final model
         **best_params
     )
     final_model.fit(X_train, y_train)


### PR DESCRIPTION
This commit updates the XGBoost model training script (`scripts/train_xgboost_model.py`) to leverage GPU hardware for significantly faster training times.

As per the user's request, the `tree_method` parameter has been set to `'gpu_hist'` in two places:
1.  During the Optuna hyperparameter search.
2.  During the final model training with the best parameters.

This allows XGBoost to use NVIDIA CUDA for computation, which should drastically reduce the time required for the model training steps of the pipeline. The user's machine must have a compatible NVIDIA GPU and the necessary CUDA toolkit installed for this to take effect.