### PR TITLE
fix(evaluate): Join 'close' column to fix KeyError

### DIFF
--- a/kost1ktrade/backend/scripts/evaluate_model.py
+++ b/kost1ktrade/backend/scripts/evaluate_model.py
@@ -130,9 +130,9 @@ def main(asset: str, timeframe: str):
         labeled_data_path = os.path.join(LABELED_DATA_DIR, f'{asset}_{timeframe}_labeled.parquet')
         labeled_df = pd.read_parquet(labeled_data_path)
 
-        # Join the ATR column into the predictions dataframe for financial calculations
-        # We only need the ATRr_14 column and it should align on the timestamp index
-        predictions_df = predictions_df.join(labeled_df[['ATRr_14']])
+        # Join the ATR and close columns into the predictions dataframe for financial calculations
+        # These are needed for the backtesting simulation
+        predictions_df = predictions_df.join(labeled_df[['ATRr_14', 'close']])
         predictions_df.dropna(inplace=True) # Drop rows where join might have failed
 
     except FileNotFoundError as e:


### PR DESCRIPTION
The `evaluate_model.py` script requires both the `ATRr_14` and `close` columns for its financial calculations. The script was previously only joining the `ATRr_14` column to the out-of-sample predictions DataFrame, which caused a `KeyError: 'close'` when trying to calculate the value of a position.

This change modifies the script to join both the `ATRr_14` and `close` columns from the labeled data file, ensuring all necessary data is available for the evaluation function.