### PR TITLE
Fix: Harden data pipeline against edge cases

### DIFF
--- a/kost1ktrade/backend/scripts/evaluate_model.py
+++ b/kost1ktrade/backend/scripts/evaluate_model.py
@@ -80,9 +80,11 @@ def calculate_financial_metrics(
 
     # --- Final Metrics Calculation ---
     if not trades_list:
+        # If no trades were made, return zero for metrics.
+        # The 'capital' at this point is the initial capital as it was never modified.
         return {
             "sharpe_ratio": 0, "profit_factor": 0, "max_drawdown": 0,
-            "win_rate": 0, "total_trades": 0, "final_capital": initial_capital
+            "win_rate": 0, "total_trades": 0, "final_capital": capital
         }
 
     total_trades = len(trades_list)

--- a/kost1ktrade/backend/scripts/run_backtest.py
+++ b/kost1ktrade/backend/scripts/run_backtest.py
@@ -38,6 +38,8 @@ def calculate_sortino_for_optuna(predictions: pd.DataFrame) -> float:
         pnl = 0
 
         # Decide trade direction
+        if trade['atr'] <= 0: continue # Prevent division by zero
+
         if trade['proba_buy'] > threshold:
             position_size = (capital * risk_per_trade) / (trade['atr'] * sl_atr_mult)
             # Original y_true: -1 (Sell), 0 (Hold), 1 (Buy). Mapped y_true: 0, 1, 2.

--- a/kost1ktrade/backend/scripts/train_model.py
+++ b/kost1ktrade/backend/scripts/train_model.py
@@ -55,6 +55,9 @@ def optimize_hyperparameters(X_train, y_train):
             X_train_fold, X_val_fold = X_train.iloc[train_index], X_train.iloc[val_index]
             y_train_fold, y_val_fold = y_train.iloc[train_index], y_train.iloc[val_index]
 
+            if X_val_fold.empty:
+                continue
+
             model = lgb.LGBMClassifier(**param)
             model.fit(X_train_fold, y_train_fold)
             preds = model.predict(X_val_fold)
@@ -158,6 +161,11 @@ def train_model(symbol: str, timeframe: str, start_date: str, end_date: str):
     print(f"Dropping {len(to_drop)} highly correlated features: {to_drop}")
     X_train = X_train.drop(columns=to_drop)
     X_test = X_test.drop(columns=to_drop)
+
+    if X_train.empty:
+        print(f"ERROR: No features remaining after correlation filtering for {symbol}. Skipping training.")
+        return
+
     print("--- Feature Selection Complete ---\n")
 
     # 9. Model Training

--- a/kost1ktrade/backend/scripts/train_xgboost_model.py
+++ b/kost1ktrade/backend/scripts/train_xgboost_model.py
@@ -74,6 +74,9 @@ def optimize_hyperparameters_xgb(X_train, y_train, n_trials: int):
             X_train_fold, X_val_fold = X_train.iloc[train_index], X_train.iloc[val_index]
             y_train_fold, y_val_fold = y_train.iloc[train_index], y_train.iloc[val_index]
 
+            if X_val_fold.empty:
+                continue
+
             model = xgb.XGBClassifier(**param)
             model.fit(X_train_fold, y_train_fold)
 
@@ -116,6 +119,10 @@ def train_xgboost_model(symbol: str, timeframe: str):
         print("Please run 'process_features.py' and 'apply_labels.py' first.")
         return
 
+    if labeled_df.empty:
+        print(f"ERROR: Labeled data file for {symbol} is empty. Skipping training.")
+        return
+
     # 2. Prepare Data (define features and target)
     # Drop non-feature columns
     cols_to_drop = ['symbol', 'interval', 'open', 'high', 'low', 'close', 'volume', 'event_end_time', 'label']
@@ -123,6 +130,10 @@ def train_xgboost_model(symbol: str, timeframe: str):
 
     # Ensure all feature columns are numeric
     X = X.select_dtypes(include=np.number)
+
+    if X.empty:
+        print(f"ERROR: No numeric features found for {symbol}. Skipping training.")
+        return
 
     y = labeled_df['label'].copy()
 

--- a/kost1ktrade/backend/src/ml/feature_generator.py
+++ b/kost1ktrade/backend/src/ml/feature_generator.py
@@ -28,7 +28,8 @@ def _calculate_vwap(df: pd.DataFrame) -> pd.Series:
     cum_vol = grouped['volume'].transform('cumsum')
     cum_vol_price = (df['close'] * df['volume']).groupby(df.index.date).transform('cumsum')
 
-    vwap = (cum_vol_price / cum_vol).fillna(0)
+    # Replace 0 with NaN in the denominator to avoid division by zero errors
+    vwap = (cum_vol_price / cum_vol.replace(0, np.nan)).fillna(0)
     return vwap
 
 def create_features(df: pd.DataFrame) -> pd.DataFrame:
@@ -152,7 +153,8 @@ def create_labels(df: pd.DataFrame, look_forward_periods: int = 4, atr_multiplie
     # --- CRITICAL FIX: Calculate ATR percentage correctly ---
     # The ATR from pandas_ta is in raw price units, not percentage.
     # We must normalize it by the current price to compare it with returns.
-    df['atr_pct'] = df[atr_col] / df['close']
+    # Replace 0 with NaN in the denominator to avoid division by zero errors.
+    df['atr_pct'] = (df[atr_col] / df['close'].replace(0, np.nan)).fillna(0)
 
     # Define dynamic thresholds based on volatility
     # Threshold = Multiplier * Normalized ATR


### PR DESCRIPTION
This commit introduces a series of robustness improvements across the data processing and model training pipeline to prevent crashes from common edge cases.

The following changes were made:

1.  **`evaluate_model.py`**:
    *   Fixed the original `NameError` that occurred when a backtest produced zero trades by using the correctly scoped `capital` variable.

2.  **`src/ml/feature_generator.py`**:
    *   Protected the VWAP calculation against division-by-zero errors that could occur if a day's first trading volume was zero.
    *   Protected the ATR percentage calculation against division-by-zero errors if a `close` price was zero.

3.  **`run_backtest.py`**:
    *   Added a check to the `calculate_sortino_for_optuna` function to prevent a division-by-zero error during position sizing if an asset's ATR was zero.

4.  **`train_xgboost_model.py` & `train_model.py`**:
    *   Added checks to gracefully handle cases where the input DataFrame is empty after loading.
    *   Added checks to ensure the feature set `X` is not empty before proceeding with scaling and training.
    *   Hardened the Optuna hyperparameter optimization loops by adding checks for empty validation folds, preventing crashes during cross-validation.