### PR TITLE
Final Fix: Relax strategy rules and ensure Optuna runs

### DIFF
--- a/kost1ktrade/backend/scripts/train_xgboost_model.py
+++ b/kost1ktrade/backend/scripts/train_xgboost_model.py
@@ -53,22 +53,7 @@ FINAL_FEATURE_SET = SPECIALIZED_FEATURES + LAGGED_FEATURES
 def optimize_hyperparameters_xgb(X_train, y_train, n_trials: int, scale_pos_weight: float):
     """
     Performs hyperparameter optimization for a binary XGBoost classifier.
-    Skips optimization and returns defaults if the dataset is too small.
     """
-    MIN_SAMPLES_FOR_OPTUNA = 20
-    if len(X_train) < MIN_SAMPLES_FOR_OPTUNA:
-        print(f"WARNING: Training set size ({len(X_train)}) is less than {MIN_SAMPLES_FOR_OPTUNA}. Skipping Optuna and using default parameters.")
-        return {
-            'n_estimators': 100,
-            'learning_rate': 0.05,
-            'max_depth': 5,
-            'subsample': 0.8,
-            'colsample_bytree': 0.8,
-            'gamma': 0,
-            'lambda': 1,
-            'alpha': 0
-        }
-
     def objective(trial):
         param = {
             'objective': 'binary:logistic',

--- a/kost1ktrade/backend/src/strategies/confluence_engine.py
+++ b/kost1ktrade/backend/src/strategies/confluence_engine.py
@@ -43,9 +43,9 @@ def generate_signals(dataframe: pd.DataFrame, strategy_type: str = 'advanced') -
     long_trend_condition = df['EMA_fast'] > df['EMA_slow']
     short_trend_condition = df['EMA_fast'] < df['EMA_slow']
 
-    # RSI Trigger Conditions (Crossover logic)
-    rsi_cross_up = (df['RSI'] > rsi_entry_level) & (df['RSI'].shift(1) <= rsi_entry_level)
-    rsi_cross_down = (df['RSI'] < rsi_entry_level) & (df['RSI'].shift(1) >= rsi_entry_level)
+    # RSI Trigger Conditions (State-based logic)
+    rsi_state_long = df['RSI'] > rsi_entry_level
+    rsi_state_short = df['RSI'] < rsi_entry_level
 
     # Volume Confirmation
     volume_confirmation_long = df['OBV'] > df['OBV_SMA']
@@ -57,14 +57,14 @@ def generate_signals(dataframe: pd.DataFrame, strategy_type: str = 'advanced') -
     # --- Combine Conditions for Basic Strategy (Strategy 2) ---
     long_signal_basic = (
         long_trend_condition &
-        rsi_cross_up &
+        rsi_state_long &
         volume_confirmation_long &
         volatility_filter
     )
 
     short_signal_basic = (
         short_trend_condition &
-        rsi_cross_down &
+        rsi_state_short &
         volume_confirmation_short &
         volatility_filter
     )


### PR DESCRIPTION
This commit addresses the final user feedback to ensure the pipeline is both robust and meaningful.

1.  **Relax RSI Rule in `confluence_engine.py`**: The RSI trigger condition has been changed from a strict one-candle crossover event to a state-based check (`RSI > 50`). This significantly increases the number of generated signals, providing a more viable dataset for the ML model and making the pipeline's output more meaningful.

2.  **Ensure Optuna Always Runs in `train_xgboost_model.py`**: Removed the guard clause that skipped hyperparameter optimization for small datasets. This is per a direct user request to ensure this crucial step is not bypassed. The adaptive `n_splits` logic for `TimeSeriesSplit` is retained to prevent crashes, making the process both mandatory and robust.

This set of changes should represent the final, correct, and fully operational version of the refactored pipeline.