### PR TITLE
Fix: Resolve multiple errors in data processing pipeline

### DIFF
--- a/kost1ktrade/backend/scripts/create_production_model.py
+++ b/kost1ktrade/backend/scripts/create_production_model.py
@@ -32,7 +32,7 @@ def select_features(X: pd.DataFrame, y: pd.Series):
 
     le = LabelEncoder()
     y_encoded = le.fit_transform(y)
-    model = lgb.LGBMClassifier(objective='multiclass', n_estimators=100, random_state=42, n_jobs=-1)
+    model = lgb.LGBMClassifier(objective='binary', n_estimators=100, random_state=42, n_jobs=-1)
     model.fit(X, y_encoded)
 
     explainer = shap.TreeExplainer(model)
@@ -101,7 +101,7 @@ def objective(trial, X_train, y_train, event_end_times, selected_features):
 
     pipeline = Pipeline([
         ('scaler', StandardScaler()),
-        ('model', lgb.LGBMClassifier(objective='multiclass', num_class=3, random_state=42, **params))
+        ('model', lgb.LGBMClassifier(objective='binary', random_state=42, **params))
     ])
 
     X_selected = X_train[selected_features]
@@ -191,7 +191,7 @@ def main(asset: str, timeframe: str):
 
         pipeline = Pipeline([
             ('scaler', StandardScaler()),
-            ('model', lgb.LGBMClassifier(objective='multiclass', num_class=3, random_state=42, **best_params))
+            ('model', lgb.LGBMClassifier(objective='binary', random_state=42, **best_params))
         ])
         y_train_encoded = LabelEncoder().fit_transform(y_train)
         pipeline.fit(X_train[final_selected_features], y_train_encoded)
@@ -222,7 +222,7 @@ def main(asset: str, timeframe: str):
     print("\nTraining final production model on the full dataset...")
     final_pipeline = Pipeline([
         ('scaler', StandardScaler()),
-        ('model', lgb.LGBMClassifier(objective='multiclass', num_class=3, random_state=42, **best_params))
+        ('model', lgb.LGBMClassifier(objective='binary', random_state=42, **best_params))
     ])
     y_full_encoded = LabelEncoder().fit_transform(y_full)
     final_pipeline.fit(X_full[final_selected_features], y_full_encoded)


### PR DESCRIPTION
This commit addresses two critical errors that caused the data processing and model training pipeline to fail.

1.  **Fix `KeyError: 'event_end_time'` in `create_production_model.py`:** The `apply_labels.py` script was not correctly generating or saving the `event_end_time` column, which is essential for downstream purged time-series cross-validation. The script has been modified to:
    - Capture the timestamp of the trade outcome (stop-loss or take-profit).
    - Use a more robust method to merge this new column into the final dataframe, ensuring it is present in the saved parquet file.

2.  **Fix `LightGBMError` in `create_production_model.py`:** The script was incorrectly configured to use a multiclass LightGBM model (`objective='multiclass'`) for a binary classification task (labels are 0 or 1). This has been corrected by changing the objective to `'binary'` and removing the unnecessary `num_class` parameter in all `LGBMClassifier` initializations within the script.

These changes together resolve the pipeline failures and allow the process to run to completion.