### PR TITLE
Fix: Implement full funding rate history download from OKX

### DIFF
--- a/kost1ktrade/backend/scripts/collect_all_data.py
+++ b/kost1ktrade/backend/scripts/collect_all_data.py
@@ -125,42 +125,43 @@ def main(days_history: int):
                 time.sleep(1)
 
             # --- Funding Rate Data ---
-            print(f"\n--- Collecting {asset} Funding Rates ---")
+            print(f"\n--- Collecting {asset} Funding Rates (Full History Method) ---")
+            instrument_family = f"{asset}-USDT" # Instrument family for the download API
             latest_fr_ms = data_collector.get_latest_funding_rate_timestamp(symbol)
+
+            start_date_fr = None
             if latest_fr_ms:
-                since_fr_ms = latest_fr_ms + 1
-                print(f"Found existing funding rate data up to {datetime.fromtimestamp(latest_fr_ms/1000).strftime('%Y-%m-%d %H:%M:%S')}.")
+                # Start from the day after the last record
+                start_date_fr = datetime.fromtimestamp(latest_fr_ms / 1000, UTC) + timedelta(days=1)
+                print(f"Found existing funding rate data up to {datetime.fromtimestamp(latest_fr_ms/1000, UTC).strftime('%Y-%m-%d %H:%M:%S')}.")
             else:
-                since_fr_ms = int((end_date - timedelta(days=days_history)).timestamp() * 1000)
-                print(f"No existing funding rate data found. Starting full history download from {datetime.fromtimestamp(since_fr_ms/1000).strftime('%Y-%m-%d %H:%M:%S')}.")
+                # No data, start from the beginning of the history period
+                start_date_fr = end_date - timedelta(days=days_history)
+                print(f"No existing funding rate data found. Starting full history download from {start_date_fr.strftime('%Y-%m-%d')}.")
 
-            if since_fr_ms < int(end_date.timestamp() * 1000):
-                print(f"Fetching funding rate data from {datetime.fromtimestamp(since_fr_ms/1000).strftime('%Y-%m-%d %H:%M:%S')} to now...")
-                all_fr_data = []
-                current_since = since_fr_ms
-                while current_since < int(end_date.timestamp() * 1000):
-                    fr_chunk = data_collector.fetch_funding_rate_history(symbol=symbol, since=current_since, limit=100)
-                    if not fr_chunk:
-                        break # No more data from exchange
+            # Ensure we only fetch if the start date is before today
+            if start_date_fr.date() < end_date.date():
+                start_date_str = start_date_fr.strftime('%Y-%m-%d')
+                end_date_str = end_date.strftime('%Y-%m-%d')
+                print(f"Fetching full funding rate history for {instrument_family} from {start_date_str} to {end_date_str}...")
 
-                    last_ts_in_all_data = all_fr_data[-1]['timestamp'] if all_fr_data else 0
-                    new_data = [d for d in fr_chunk if d['timestamp'] > last_ts_in_all_data]
-                    if not new_data:
-                        break
-
-                    all_fr_data.extend(new_data)
-                    current_since = new_data[-1]['timestamp'] + 1
-                    time.sleep(data_collector.exchange.rateLimit / 1000)
+                # Use the new method to fetch data from downloadable files
+                all_fr_data = data_collector.fetch_full_funding_rate_history(
+                    instrument_family=instrument_family,
+                    start_date_str=start_date_str,
+                    end_date_str=end_date_str
+                )
 
                 if all_fr_data:
+                    # The new method returns data in a CCXT-compatible format, ready for saving.
                     count = data_collector.save_funding_rates_to_db(all_fr_data, symbol)
                     summary["crypto_specific"][asset]["Funding Rates"] = count
-                    print(f"-> Saved {count} new funding rate entries for {asset}.")
+                    print(f"-> Saved/Updated {count} funding rate entries for {asset}.")
                 else:
-                    print("-> No new data returned from the exchange.")
+                    print("-> No new funding rate data was fetched or processed.")
             else:
                 print(f"Funding rate data for {asset} is already up to date.")
-            time.sleep(1)
+            time.sleep(1) # Be polite to the API
 
         print("\n" + "="*60)
         print("=== FINAL DATA COLLECTION SUMMARY" + " "*29 + "===")

--- a/kost1ktrade/backend/src/data_collector/collector.py
+++ b/kost1ktrade/backend/src/data_collector/collector.py
@@ -223,6 +223,105 @@ class DataCollector:
 
         raise ExchangeError(f"Failed to fetch funding rates for {symbol} after {retries} retries.")
 
+    def fetch_full_funding_rate_history(self, instrument_family: str, start_date_str: str, end_date_str: str) -> List[dict]:
+        """
+        Fetches the complete funding rate history for a given instrument family over a date range
+        by using the OKX historical market data download endpoint. This is necessary because
+        the standard CCXT `fetchFundingRateHistory` endpoint for OKX is limited to 3 months.
+        :param instrument_family: The instrument family, e.g., 'BTC-USDT'.
+        :param start_date_str: The start date in 'YYYY-MM-DD' format.
+        :param end_date_str: The end date in 'YYYY-MM-DD' format.
+        :return: A list of funding rate data dictionaries, compatible with CCXT format.
+        """
+        print(f"Attempting to download full funding rate history for {instrument_family} from {start_date_str} to {end_date_str}...")
+
+        # Convert dates to milliseconds timestamp
+        try:
+            begin_ms = int(datetime.datetime.strptime(start_date_str, "%Y-%m-%d").timestamp() * 1000)
+            end_ms = int(datetime.datetime.strptime(end_date_str, "%Y-%m-%d").timestamp() * 1000)
+        except ValueError:
+            print("Error: Invalid date format. Please use 'YYYY-MM-DD'.")
+            return []
+
+        # --- 1. Get the list of file URLs from the historical data API ---
+        base_url = "https://www.okx.com/api/v5/public/market-data-history"
+        params = {
+            "module": "funding_rate",
+            "instType": "SWAP",
+            "instFamilyList": instrument_family,
+            "dateAggrType": "daily",
+            "begin": begin_ms,
+            "end": end_ms,
+        }
+
+        try:
+            print("Requesting list of historical data files...")
+            response = requests.get(base_url, params=params)
+            response.raise_for_status()
+            data = response.json()
+        except requests.exceptions.RequestException as e:
+            print(f"Error fetching historical data file list: {e}")
+            return []
+
+        if data.get("code") != "0" or not data.get("data"):
+            print(f"API Error when fetching file list: {data.get('msg', 'No data returned for the specified period.')}")
+            return []
+
+        download_urls = []
+        if data["data"] and data["data"][0].get("details"):
+             for detail in data["data"][0]["details"]:
+                for group in detail.get("groupDetails", []):
+                    download_urls.append(group["url"])
+
+        if not download_urls:
+            print("No downloadable files found for the specified period.")
+            return []
+
+        print(f"Found {len(download_urls)} files. Starting download and processing...")
+
+        # --- 2. Download and process each file ---
+        all_data_frames = []
+        for url in download_urls:
+            try:
+                print(f"  Downloading: {url.split('/')[-1]}")
+                file_response = requests.get(url, stream=True, timeout=60)
+                file_response.raise_for_status()
+
+                with zipfile.ZipFile(io.BytesIO(file_response.content)) as z:
+                    csv_filename = z.namelist()[0]
+                    with z.open(csv_filename) as csv_file:
+                        df = pd.read_csv(csv_file)
+                        all_data_frames.append(df)
+            except Exception as e:
+                print(f"  Failed to download or process file {url}. Error: {e}")
+                continue # Move to the next file
+
+        if not all_data_frames:
+            print("Data processing failed for all files.")
+            return []
+
+        # --- 3. Consolidate and format the data ---
+        full_history_df = pd.concat(all_data_frames, ignore_index=True)
+
+        # Convert to a list of dicts in a format similar to CCXT
+        # This format is: {'symbol', 'timestamp', 'datetime', 'fundingRate', 'info'}
+        ccxt_formatted_data = []
+        for _, row in full_history_df.iterrows():
+            ts = int(row['fundingTime'])
+            ccxt_formatted_data.append({
+                'symbol': f"{instrument_family}-SWAP",
+                'timestamp': ts,
+                'datetime': datetime.datetime.fromtimestamp(ts / 1000, tz=datetime.timezone.utc).isoformat(),
+                'fundingRate': float(row['fundingRate']),
+                'info': row.to_dict() # Keep original data in 'info'
+            })
+
+        # Sort by timestamp ascending
+        ccxt_formatted_data.sort(key=lambda x: x['timestamp'])
+
+        print(f"Successfully processed {len(ccxt_formatted_data)} total funding rate records.")
+        return ccxt_formatted_data
+
 
     def get_latest_funding_rate_timestamp(self, symbol: str) -> int:
         """


### PR DESCRIPTION
This commit resolves an issue where the data collector was only fetching the last 3 months of funding rate history from OKX.

The previous implementation used the standard `fetchFundingRateHistory` method, which is limited by the exchange's API.

This has been fixed by:
1.  Adding a new method, `fetch_full_funding_rate_history`, to the `DataCollector` class. This method uses the correct `GET /api/v5/public/market-data-history` endpoint to retrieve URLs for historical data archives.
2.  Implementing logic within this new method to download, unzip, and parse the historical data files.
3.  Updating the main data collection script, `collect_all_data.py`, to use this new method, ensuring that the full, available history is fetched and stored in the database.