### PR TITLE
Fix: Use monthly aggregation for OKX funding rate history

### DIFF
--- a/kost1ktrade/backend/scripts/collect_all_data.py
+++ b/kost1ktrade/backend/scripts/collect_all_data.py
@@ -125,43 +125,42 @@ def main(days_history: int):
                 time.sleep(1)
 
             # --- Funding Rate Data ---
-            print(f"\n--- Collecting {asset} Funding Rates (Full History Method) ---")
-            instrument_family = f"{asset}-USDT" # Instrument family for the download API
+            print(f"\n--- Collecting {asset} Funding Rates ---")
             latest_fr_ms = data_collector.get_latest_funding_rate_timestamp(symbol)
-
-            start_date_fr = None
             if latest_fr_ms:
-                # Start from the day after the last record
-                start_date_fr = datetime.fromtimestamp(latest_fr_ms / 1000, UTC) + timedelta(days=1)
-                print(f"Found existing funding rate data up to {datetime.fromtimestamp(latest_fr_ms/1000, UTC).strftime('%Y-%m-%d %H:%M:%S')}.")
+                since_fr_ms = latest_fr_ms + 1
+                print(f"Found existing funding rate data up to {datetime.fromtimestamp(latest_fr_ms/1000).strftime('%Y-%m-%d %H:%M:%S')}.")
             else:
-                # No data, start from the beginning of the history period
-                start_date_fr = end_date - timedelta(days=days_history)
-                print(f"No existing funding rate data found. Starting full history download from {start_date_fr.strftime('%Y-%m-%d')}.")
+                since_fr_ms = int((end_date - timedelta(days=days_history)).timestamp() * 1000)
+                print(f"No existing funding rate data found. Starting full history download from {datetime.fromtimestamp(since_fr_ms/1000).strftime('%Y-%m-%d %H:%M:%S')}.")
 
-            # Ensure we only fetch if the start date is before today
-            if start_date_fr.date() < end_date.date():
-                start_date_str = start_date_fr.strftime('%Y-%m-%d')
-                end_date_str = end_date.strftime('%Y-%m-%d')
-                print(f"Fetching full funding rate history for {instrument_family} from {start_date_str} to {end_date_str}...")
+            if since_fr_ms < int(end_date.timestamp() * 1000):
+                print(f"Fetching funding rate data from {datetime.fromtimestamp(since_fr_ms/1000).strftime('%Y-%m-%d %H:%M:%S')} to now...")
+                all_fr_data = []
+                current_since = since_fr_ms
+                while current_since < int(end_date.timestamp() * 1000):
+                    fr_chunk = data_collector.fetch_funding_rate_history(symbol=symbol, since=current_since, limit=100)
+                    if not fr_chunk:
+                        break # No more data from exchange
 
-                # Use the new method to fetch data from downloadable files
-                all_fr_data = data_collector.fetch_full_funding_rate_history(
-                    instrument_family=instrument_family,
-                    start_date_str=start_date_str,
-                    end_date_str=end_date_str
-                )
+                    last_ts_in_all_data = all_fr_data[-1]['timestamp'] if all_fr_data else 0
+                    new_data = [d for d in fr_chunk if d['timestamp'] > last_ts_in_all_data]
+                    if not new_data:
+                        break
+
+                    all_fr_data.extend(new_data)
+                    current_since = new_data[-1]['timestamp'] + 1
+                    time.sleep(data_collector.exchange.rateLimit / 1000)
 
                 if all_fr_data:
-                    # The new method returns data in a CCXT-compatible format, ready for saving.
                     count = data_collector.save_funding_rates_to_db(all_fr_data, symbol)
                     summary["crypto_specific"][asset]["Funding Rates"] = count
-                    print(f"-> Saved/Updated {count} funding rate entries for {asset}.")
+                    print(f"-> Saved {count} new funding rate entries for {asset}.")
                 else:
-                    print("-> No new funding rate data was fetched or processed.")
+                    print("-> No new data returned from the exchange.")
             else:
                 print(f"Funding rate data for {asset} is already up to date.")
-            time.sleep(1) # Be polite to the API
+            time.sleep(1)
 
         print("\n" + "="*60)
         print("=== FINAL DATA COLLECTION SUMMARY" + " "*29 + "===")

--- a/kost1ktrade/backend/src/data_collector/collector.py
+++ b/kost1ktrade/backend/src/data_collector/collector.py
@@ -228,7 +228,7 @@ class DataCollector:
         Fetches the complete funding rate history for a given instrument family over a date range
         by using the OKX historical market data download endpoint. This is necessary because
         the standard CCXT `fetchFundingRateHistory` endpoint for OKX is limited to 3 months.
-        This method handles the 14-day range limit by fetching data in chunks.
+        This method handles the API limitations by fetching data in monthly chunks.
         :param instrument_family: The instrument family, e.g., 'BTC-USDT'.
         :param start_date_str: The start date in 'YYYY-MM-DD' format.
         :param end_date_str: The end date in 'YYYY-MM-DD' format.
@@ -243,16 +243,21 @@ class DataCollector:
             print("Error: Invalid date format. Please use 'YYYY-MM-DD'.")
             return []
 
-        # --- 1. Get the list of file URLs by iterating in 14-day chunks ---
+        # --- 1. Get the list of file URLs by iterating month by month ---
         base_url = "https://www.okx.com/api/v5/public/market-data-history"
         download_urls = set() # Use a set to avoid duplicate URLs
         current_start = start_date
 
         while current_start <= end_date:
-            chunk_end = current_start + datetime.timedelta(days=13)
+            # Set the end of the chunk to the last day of the current month
+            next_month = current_start.replace(day=28) + datetime.timedelta(days=4)
+            chunk_end = next_month - datetime.timedelta(days=next_month.day)
+
             if chunk_end > end_date:
                 chunk_end = end_date
 
+            # Per documentation, timestamps are treated as UTC+8.
+            # We will use simple timestamps and let the server handle timezone conversion.
             begin_ms = int(current_start.timestamp() * 1000)
             end_ms = int(chunk_end.timestamp() * 1000)
 
@@ -260,13 +265,13 @@ class DataCollector:
                 "module": "3", # 3 = funding_rate
                 "instType": "SWAP",
                 "instFamilyList": instrument_family,
-                "dateAggrType": "daily",
+                "dateAggrType": "monthly", # Changed from 'daily' to 'monthly'
                 "begin": begin_ms,
                 "end": end_ms,
             }
 
             try:
-                print(f"Requesting file list for {current_start.strftime('%Y-%m-%d')} to {chunk_end.strftime('%Y-%m-%d')}...")
+                print(f"Requesting file list for {current_start.strftime('%Y-%m')}...")
                 response = requests.get(base_url, params=params, timeout=30)
                 response.raise_for_status()
                 data = response.json()
@@ -276,14 +281,16 @@ class DataCollector:
                         for detail in data["data"][0]["details"]:
                             for group in detail.get("groupDetails", []):
                                 download_urls.add(group["url"])
+                elif data.get("code") == "52000": # Specific code for "No market data found"
+                    print(f"Info: No monthly data file found for {current_start.strftime('%Y-%m')}. This is expected for some periods.")
                 else:
-                    print(f"API Warning/Error for chunk: {data.get('msg', 'No data returned')}")
+                    print(f"API Warning/Error for chunk {current_start.strftime('%Y-%m')}: {data.get('msg', 'No data returned')}")
 
             except requests.exceptions.RequestException as e:
-                print(f"Error fetching file list for chunk {current_start.strftime('%Y-%m-%d')}: {e}")
+                print(f"Error fetching file list for chunk {current_start.strftime('%Y-%m')}: {e}")
 
-            # Move to the next chunk
-            current_start += datetime.timedelta(days=14)
+            # Move to the start of the next month
+            current_start = (chunk_end + datetime.timedelta(days=1)).replace(day=1)
             time.sleep(1) # Be polite
 
         if not download_urls:


### PR DESCRIPTION
This commit corrects the implementation for fetching full funding rate history from the OKX `market-data-history` endpoint.

The previous implementation failed because it used `dateAggrType='daily'` with a specific `instFamilyList`, which is an unsupported parameter combination for the funding rate module (`module=3`) according to the API documentation.

The fix consists of:
1.  Changing `dateAggrType` from `'daily'` to `'monthly'`.
2.  Updating the date iteration logic to fetch data in monthly chunks instead of 14-day chunks.
3.  This ensures the API requests are valid and that the service can return the correct URLs for historical data files.