### PR TITLE
fix(data): Add timeout to exchange connection

### DIFF
--- a/kost1ktrade/backend/src/data_collector/collector.py
+++ b/kost1ktrade/backend/src/data_collector/collector.py
@@ -30,6 +30,7 @@ class DataCollector:
                 'options': {
                     'defaultType': 'swap',  # Changed from 'spot' to 'swap' for perpetuals
                 },
+                'timeout': 30000,  # 30-second timeout for exchange requests
             })
         except AttributeError:
             raise ValueError(f"Exchange '{exchange_id}' is not supported by ccxt.")


### PR DESCRIPTION
The `run_full_pipeline.py` script was hanging during the initialization of the `DataCollector`.

This was caused by the `self.exchange.load_markets()` call, which can block indefinitely if there are network issues or the exchange API is slow to respond.

This change adds a 30-second timeout to the `ccxt` exchange configuration. This ensures that instead of hanging, the script will raise a `RequestTimeout` error if loading the markets takes too long, making the data collection pipeline more robust.