### PR TITLE
fix(data): Add timeouts and fix loop in data collector

### DIFF
--- a/kost1ktrade/backend/src/data_collector/collector.py
+++ b/kost1ktrade/backend/src/data_collector/collector.py
@@ -290,8 +290,8 @@ class DataCollector:
             except requests.exceptions.RequestException as e:
                 print(f"Error fetching file list for chunk {current_start.strftime('%Y-%m')}: {e}")
 
-            # Move to the start of the next month
-            current_start = (chunk_end + datetime.timedelta(days=1)).replace(day=1)
+            # Move to the start of the next month robustly
+            current_start = (current_start.replace(day=28) + datetime.timedelta(days=4)).replace(day=1)
             time.sleep(1) # Be polite
 
         if not download_urls:


### PR DESCRIPTION
This commit addresses several issues in the data collection pipeline that caused it to hang or enter an infinite loop.

1.  **Initial Hang:** The `ccxt.load_markets()` call would block indefinitely on slow connections. This is fixed by adding a 30-second timeout to the main `ccxt` exchange configuration.

2.  **Funding Rate Hang:** The `requests.get()` calls to the OKX API for funding rate history would hang on connection. This is fixed by providing a more robust timeout tuple `(connect_timeout, read_timeout)` to these requests.

3.  **Infinite Loop:** The logic to iterate through months for funding rate history contained a bug that caused an infinite loop when processing the final, partial month. This is fixed by using a more reliable method to calculate the start of the next month.

These changes make the data collection pipeline significantly more robust.