### PR TITLE
debug(data): Print funding rate columns

### DIFF
--- a/kost1ktrade/backend/src/data_collector/collector.py
+++ b/kost1ktrade/backend/src/data_collector/collector.py
@@ -323,6 +323,7 @@ class DataCollector:
 
         # --- 3. Consolidate and format the data ---
         full_history_df = pd.concat(all_data_frames, ignore_index=True)
+        print(f"DEBUG: DataFrame columns are: {full_history_df.columns.tolist()}")
         full_history_df.drop_duplicates(subset=['fundingTime', 'instId'], keep='first', inplace=True)
 
 


### PR DESCRIPTION
The data collection pipeline is failing with a `KeyError` when processing historical funding rate data. This is likely due to a mismatch between the expected column names and the actual column names in the data downloaded from OKX.

This commit adds a temporary debug statement to print the list of columns from the downloaded DataFrame. This will allow us to identify the correct column names and apply a permanent fix.