### PR TITLE
Fix KeyError in funding rate data collection pipeline.

### DIFF
--- a/kost1ktrade/backend/src/data_collector/collector.py
+++ b/kost1ktrade/backend/src/data_collector/collector.py
@@ -324,6 +324,17 @@ class DataCollector:
         # --- 3. Consolidate and format the data ---
         full_history_df = pd.concat(all_data_frames, ignore_index=True)
         print(f"DEBUG: DataFrame columns are: {full_history_df.columns.tolist()}")
+
+        # (FIX) Rename columns to match the expected format, as CSV headers are different.
+        # CSV: 'instrument_name', 'funding_rate', 'funding_time'
+        # Expected: 'instId', 'fundingRate', 'fundingTime'
+        if not full_history_df.empty:
+            full_history_df.rename(columns={
+                'instrument_name': 'instId',
+                'funding_rate': 'fundingRate',
+                'funding_time': 'fundingTime'
+            }, inplace=True)
+
         full_history_df.drop_duplicates(subset=['fundingTime', 'instId'], keep='first', inplace=True)
 
 


### PR DESCRIPTION
The `fetch_full_funding_rate_history` function was failing with a `KeyError` because the column names from the downloaded CSV files ('instrument_name', 'funding_rate', 'funding_time') did not match the expected column names ('instId', 'fundingRate', 'fundingTime') used in the data processing steps.

This change adds a renaming step to align the DataFrame column names with the expected schema before they are used, resolving the error.