### PR TITLE
fix(ml): Reduce n_splits in walk-forward validation

### DIFF
--- a/kost1ktrade/backend/scripts/create_production_model.py
+++ b/kost1ktrade/backend/scripts/create_production_model.py
@@ -183,7 +183,7 @@ def main(asset: str, timeframe: str):
     plt.savefig(shap_plot_path, bbox_inches='tight'); plt.close()
 
     # --- 3. Walk-Forward Validation and Hyperparameter Tuning ---
-    outer_cv = PurgedTimeSeriesSplit(n_splits=5, purge_buffer_days=5, embargo_pct=0.01)
+    outer_cv = PurgedTimeSeriesSplit(n_splits=3, purge_buffer_days=5, embargo_pct=0.01)
     all_reports = []
     successful_folds = 0
 


### PR DESCRIPTION
The walk-forward validation in `create_production_model.py` was failing with a memory access violation when running on small datasets.

The root cause was that the number of splits (5) created training folds that were too small, causing the LightGBM model to behave unstably.

This change reduces the number of splits from 5 to 3 to ensure each training fold is large enough to be processed reliably. This directly addresses the "Insufficient training data" warnings and is intended to prevent the subsequent crash.