### PR TITLE
feat: Lower min trades requirement for diagnostics

### DIFF
--- a/kost1ktrade/backend/scripts/evaluate_model.py
+++ b/kost1ktrade/backend/scripts/evaluate_model.py
@@ -129,7 +129,10 @@ def main(asset: str, timeframe: str):
 
     results_df = pd.DataFrame(results)
 
-    min_trades = settings.ML.MIN_TRADES_FOR_EVAL
+    # Temporarily lower the minimum trade requirement for diagnostic purposes, as per user request.
+    # The original value is settings.ML.MIN_TRADES_FOR_EVAL (30).
+    min_trades = 15
+    print(f"INFO: Temporarily lowered minimum trades requirement to {min_trades} for this evaluation run.")
     realistic_results_df = results_df[results_df['total_trades'] >= min_trades]
 
     if realistic_results_df.empty:


### PR DESCRIPTION
Temporarily lowers the minimum trade requirement in `evaluate_model.py` from the configured value (30) to 15.

This is a diagnostic step to help determine if any profitable confidence threshold can be found with a less strict requirement, as per the user's analysis of the model's poor out-of-sample performance. The change is intended to be temporary to gather more data on the model's behavior.